### PR TITLE
sign out: logout of registry and unregister sub-man

### DIFF
--- a/src/podman-cli.ts
+++ b/src/podman-cli.ts
@@ -26,6 +26,8 @@ const PODMAN_COMMANDS = {
   SM_ACTIVATION_STATUS: () => 'machine ssh sudo subscription-manager status'.split(' '),
   SM_ACTIVATE_SUBS: (activationKeyName: string, orgId: string) =>
     `machine ssh sudo subscription-manager register --activationkey ${activationKeyName} --org ${orgId}`.split(' '),
+  SM_DEACTIVATE_SUBS: () =>
+    `machine ssh sudo subscription-manager unregister`.split(' '),
   MACHINE_STOP: () => 'machine stop'.split(' '),
   MACHINE_START: () => 'machine start'.split(' '),
 }
@@ -104,6 +106,17 @@ export async function runSubscriptionManagerActivationStatus(): Promise<number |
 export async function runSubscriptionManagerRegister(activationKeyName: string, orgId: string): Promise<number | undefined> {
   try {
     const result = await extensionApi.process.exec(getPodmanCli(), PODMAN_COMMANDS.SM_ACTIVATE_SUBS(activationKeyName, orgId));
+    return 0;
+  } catch (err) {
+    const exitCode = (err as extensionApi.RunError).exitCode;
+    console.error(`Subscription manager registration returned exit code: ${exitCode}`);
+    return exitCode;
+  }
+}
+
+export async function runSubscriptionManagerUnregister(): Promise<number | undefined> {
+  try {
+    const result = await extensionApi.process.exec(getPodmanCli(), PODMAN_COMMANDS.SM_DEACTIVATE_SUBS());
     return 0;
   } catch (err) {
     const exitCode = (err as extensionApi.RunError).exitCode;


### PR DESCRIPTION
When signing out of the Red Hat account make sure to undo the actions of signing in:
 * Logging out of `registry.redhat.io`
 * Running `subscription-manager unregister` inside the podman machine

Fixes: #41

I never wrote type script before but could copy-paste the logic together.
@dgolovin @benoitf PTAL