### PR TITLE
fix: use email and id.username scopes as defaults

### DIFF
--- a/src/authentication-service.ts
+++ b/src/authentication-service.ts
@@ -324,10 +324,12 @@ export class RedHatAuthenticationService {
         const code_verifier = generators.codeVerifier();
         const code_challenge = generators.codeChallenge(code_verifier);
 
+        // email and id.username scopes required to render user name on Authentication Settings page
+        const defaultScopes = 'openid id.username email';
         const scope = scopes;
 
         const authUrl = this.client.authorizationUrl({
-          scope: `openid ${scope}`,
+          scope: `${defaultScopes} ${scope}`,
           resource: this.config.apiUrl,
           code_challenge,
           code_challenge_method: 'S256',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,8 +63,7 @@ async function signIntoRedHatDeveloperAccount(createIfNone = true): Promise<exte
   return extensionApi.authentication.getSession(
     'redhat.authentication-provider',
     ['api.iam.registry_service_accounts', //scope that gives access to hydra service accounts API
-    'api.console', // scope that gives access to console.redhat.com APIs
-    'id.username'], // adds claim to accessToken that used to render account label
+    'api.console'], // scope that gives access to console.redhat.com APIs
     {createIfNone} // will request to login in browser if session does not exists
   );
 }


### PR DESCRIPTION
They are should be always present to have claims used in user name rendering on Authentication settings page.
For testing with #59.