### PR TITLE
register with `--force`

### DIFF
--- a/src/podman-cli.ts
+++ b/src/podman-cli.ts
@@ -25,7 +25,7 @@ const PODMAN_COMMANDS = {
   RPM_INSTALL_SM: () => 'machine ssh sudo rpm-ostree install -y subscription-manager'.split(' '),
   SM_ACTIVATION_STATUS: () => 'machine ssh sudo subscription-manager status'.split(' '),
   SM_ACTIVATE_SUBS: (activationKeyName: string, orgId: string) =>
-    `machine ssh sudo subscription-manager register --activationkey ${activationKeyName} --org ${orgId}`.split(' '),
+    `machine ssh sudo subscription-manager register --force --activationkey ${activationKeyName} --org ${orgId}`.split(' '),
   SM_DEACTIVATE_SUBS: () =>
     `machine ssh sudo subscription-manager unregister`.split(' '),
   MACHINE_STOP: () => 'machine stop'.split(' '),


### PR DESCRIPTION
`--force` will instruct subscription-manager to implicitly unregister. A defense measure against potential bugs or a pre-registered machine for some other reason.  This way, we make sure that the account and activation keys are used that we want.