### PR TITLE
chore: update to Podman Desktop API 1.9.0

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -20,7 +20,7 @@ FROM scratch
 LABEL org.opencontainers.image.title="Red Hat Account" \
   org.opencontainers.image.description="Allows the ability in Podman Desktop to login to Red Hat SSO" \
   org.opencontainers.image.vendor="Red Hat" \
-  io.podman-desktop.api.version=">= 1.7.0"
+  io.podman-desktop.api.version=">= 1.9.0"
 
 COPY package.json /extension/
 COPY LICENSE /extension/

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "publisher": "redhat",
   "license": "Apache-2.0",
   "engines": {
-    "podman-desktop": "^0.0.1"
+    "podman-desktop": "^1.9.0"
   },
   "main": "./dist/extension.js",
   "contributes": {
@@ -29,9 +29,9 @@
     "test": "vitest run --coverage"
   },
   "dependencies": {
-    "@podman-desktop/api": "0.0.202403201348-23ebd88",
+    "@podman-desktop/api": "^1.9.0",
     "@redhat-developer/rhcra-client": "^0.0.1",
-    "@redhat-developer/rhsm-client": "^0.0.4  ",
+    "@redhat-developer/rhsm-client": "^0.0.4",
     "@types/node": "^18.15.11",
     "axios": "^1.6.5",
     "js-yaml": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -312,10 +312,10 @@
   dependencies:
     esquery "^1.4.0"
 
-"@podman-desktop/api@0.0.202403201348-23ebd88":
-  version "0.0.202403201348-23ebd88"
-  resolved "https://registry.yarnpkg.com/@podman-desktop/api/-/api-0.0.202403201348-23ebd88.tgz#35967578523a7190122765c99d12397d7a69c871"
-  integrity sha512-UQn/rPyH4L1gS7kHaJJmIltAMenJWARk2kRfUMsGQ9V6e9VXC13dcY0UfOTIhu+uRwRziQ6CRfJc4q1lGKmxZw==
+"@podman-desktop/api@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@podman-desktop/api/-/api-1.9.0.tgz#5520b719da555f999c4d42184549a054d680c852"
+  integrity sha512-QFPnl+kYxWdAqoKDRplyqBDNoQj15FLtqCbYW1sq19U4OJP/BXZ9r4SNF8ndvQnBXXvATjUeCC/VAjUuwf5lqQ==
 
 "@redhat-developer/rhcra-client@^0.0.1":
   version "0.0.1"
@@ -325,7 +325,7 @@
     axios "^1.6.7"
     form-data "^4.0.0"
 
-"@redhat-developer/rhsm-client@^0.0.4  ":
+"@redhat-developer/rhsm-client@^0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@redhat-developer/rhsm-client/-/rhsm-client-0.0.4.tgz#152181f68dca1acf36813cb610c9e5887f9f92ef"
   integrity sha512-93Onlfg6z7WRffxPM2IcRaFZ8FEv0QeF2LBYaD7WY5hk4IZRoVBeqzUaT4Zd7hQ3Jw16wtuxoQfYUds7MBVOiQ==


### PR DESCRIPTION
note that for now package.json engine or io.podman-desktop.api.version in Containerfile are not enforced by Podman Desktop but better to update them