### PR TITLE
chore(ci): add E2E test workflow

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -25,7 +25,7 @@ on:
     inputs:
       organization:
         default: 'redhat-developer'
-        description: 'Organization of the Podman Desktop repository'
+        description: 'Organization of the Red Hat Account Extension repository'
         type: string
         required: true
       repositoryName:
@@ -35,13 +35,13 @@ on:
         required: true
       branch:
         default: 'main'
-        description: 'Podman Desktop Extension SSO repo branch'
+        description: 'Red Hat Account Extension repo branch'
         type: string
         required: true
 
 jobs:
   e2e-tests:
-    name: Run E2E tests
+    name: Red Hat Account Extension E2E tests
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -102,13 +102,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - name: Execute yarn in SSO Extension
+      - name: Execute yarn in Red Hat Account Extension
         working-directory: ./podman-desktop-redhat-account-ext
         run: |
           yarn add -D @podman-desktop/tests-playwright@next
           yarn --frozen-lockfile
 
-      - name: Run All E2E tests
+      - name: Run All E2E tests in Red Hat Account Extension
         working-directory: ./podman-desktop-redhat-account-ext
         env:
           PODMAN_DESKTOP_ARGS: ${{ github.workspace }}/podman-desktop

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -44,6 +44,7 @@ jobs:
     name: Red Hat Account Extension E2E tests
     runs-on: ubuntu-22.04
     steps:
+
       - uses: actions/checkout@v4
         if: github.event_name == 'workflow_dispatch'
         with:
@@ -55,6 +56,16 @@ jobs:
         if: github.event_name == 'push'
         with: 
           path: podman-desktop-redhat-account-ext
+
+      - name: Setup default repository name
+        env: 
+          EVENT: ${{ github.event_name }}
+        run: |
+          repository=podman-desktop-redhat-account-ext
+          if [[ "$EVENT" == 'workflow_dispatch' ]]; then
+            repository=${{ github.event.inputs.repositoryName }}
+          fi
+          echo "REPOSITORY=$repository" >> $GITHUB_ENV
 
       # Checkout podman desktop
       - uses: actions/checkout@v4
@@ -90,7 +101,7 @@ jobs:
           yarn test:e2e:build
 
       - name: Get yarn cache directory path
-        working-directory: ./podman-desktop-redhat-account-ext
+        working-directory: ${{ env.REPOSITORY }}
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> ${GITHUB_OUTPUT}
 
@@ -103,13 +114,13 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Execute yarn in Red Hat Account Extension
-        working-directory: ./podman-desktop-redhat-account-ext
+        working-directory: ${{ env.REPOSITORY }}
         run: |
           yarn add -D @podman-desktop/tests-playwright@next
           yarn --frozen-lockfile
 
       - name: Run All E2E tests in Red Hat Account Extension
-        working-directory: ./podman-desktop-redhat-account-ext
+        working-directory: ${{ env.REPOSITORY }}
         env:
           PODMAN_DESKTOP_ARGS: ${{ github.workspace }}/podman-desktop
         run: yarn test:e2e

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -1,0 +1,121 @@
+#
+# Copyright (C) 2024 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: e2e-tests-main
+
+on:
+  push:
+    branches: [main]
+
+  workflow_dispatch:
+    inputs:
+      organization:
+        default: 'redhat-developer'
+        description: 'Organization of the Podman Desktop repository'
+        type: string
+        required: true
+      repositoryName:
+        default: 'podman-desktop-redhat-account-ext'
+        description: 'Podman Desktop RedHat Account Extension repository name'
+        type: string
+        required: true
+      branch:
+        default: 'main'
+        description: 'Podman Desktop Extension SSO repo branch'
+        type: string
+        required: true
+
+jobs:
+  e2e-tests:
+    name: Run E2E tests
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          repository: ${{ github.event.inputs.organization }}/${{ github.event.inputs.repositoryName }}
+          ref: ${{ github.event.inputs.branch }}
+          path: ${{ github.event.inputs.repositoryName }}
+
+      - uses: actions/checkout@v4
+        if: github.event_name == 'push'
+        with: 
+          path: podman-desktop-redhat-account-ext
+
+      # Checkout podman desktop
+      - uses: actions/checkout@v4
+        with:
+          repository: containers/podman-desktop
+          ref: main
+          path: podman-desktop
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Update podman
+        run: |
+          sudo sh -c "echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_22.04/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list"
+          curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_22.04/Release.key" | sudo apt-key add -
+          sudo apt-get update -qq
+          sudo apt-get -qq -y install podman || { echo "Start fallback steps for podman nightly installation from a static mirror" && \
+            sudo sh -c "echo 'deb http://ftp.lysator.liu.se/pub/opensuse/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_22.04/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list" && \
+            curl -L "http://ftp.lysator.liu.se/pub/opensuse/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_22.04/Release.key" | sudo apt-key add - && \
+            sudo apt-get update && \
+            sudo apt-get -y install podman; }
+          podman version
+          # downgrade conmon package version to workaround issue with starting containers, see  https://github.com/containers/conmon/issues/475
+          # remove once the repository contains conmon 2.1.10
+          wget https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_22.04/amd64/conmon_2.1.2~0_amd64.deb -O /tmp/conmon_2.1.2.deb
+          sudo apt install /tmp/conmon_2.1.2.deb
+
+      - name: Build Podman Desktop for E2E tests
+        working-directory: ./podman-desktop
+        run: |
+          yarn --frozen-lockfile
+          yarn test:e2e:build
+
+      - name: Get yarn cache directory path
+        working-directory: ./podman-desktop-redhat-account-ext
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> ${GITHUB_OUTPUT}
+
+      - uses: actions/cache@v4
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Execute yarn in SSO Extension
+        working-directory: ./podman-desktop-redhat-account-ext
+        run: |
+          yarn add -D @podman-desktop/tests-playwright@next
+          yarn --frozen-lockfile
+
+      - name: Run All E2E tests
+        working-directory: ./podman-desktop-redhat-account-ext
+        env:
+          PODMAN_DESKTOP_ARGS: ${{ github.workspace }}/podman-desktop
+        run: yarn test:e2e
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: e2e-tests
+          path: ./**/tests/output/


### PR DESCRIPTION
Adding workflow that runs e2e test suite (#76) after push to merge event and on demand. It does not replace PR check that will be added as well.