### PR TITLE
chore(tests): add separate npm test target for unit and e2e test calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ dist
 node_modules
 redhat-authentication.cdix
 tests/output
+test-resources
  

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "lint:clean": "rimraf .eslintcache",
     "lint:fix": "node --max-old-space-size=6144 node_modules/eslint/bin/eslint.js --cache . --fix --ext js,ts",
     "lint:check": "node --max-old-space-size=6144 node_modules/eslint/bin/eslint.js --cache . --ext js,ts",
-    "test": "npm run test:unit && npm run test:e2e",
-    "test:unit": "vitest run --coverage",
+    "test": "vitest run --coverage",
+    "test:all": "npm run test && npm run test:e2e",
     "test:e2e:setup": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' --",
     "test:e2e": "cross-env E2E_TESTS=true npm run test:e2e:setup vitest run tests/src/ --pool=threads --poolOptions.threads.singleThread --poolOptions.threads.isolate --no-file-parallelism"
   

--- a/package.json
+++ b/package.json
@@ -39,9 +39,10 @@
     "lint:clean": "rimraf .eslintcache",
     "lint:fix": "node --max-old-space-size=6144 node_modules/eslint/bin/eslint.js --cache . --fix --ext js,ts",
     "lint:check": "node --max-old-space-size=6144 node_modules/eslint/bin/eslint.js --cache . --ext js,ts",
-    "test": "vitest run --coverage",
+    "test": "npm run test:unit && npm run test:e2e",
+    "test:unit": "vitest run --coverage",
     "test:e2e:setup": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' --",
-    "test:e2e": "npm run test:e2e:setup vitest run tests/src/ --pool=threads --poolOptions.threads.singleThread --poolOptions.threads.isolate --no-file-parallelism"
+    "test:e2e": "cross-env E2E_TESTS=true npm run test:e2e:setup vitest run tests/src/ --pool=threads --poolOptions.threads.singleThread --poolOptions.threads.isolate --no-file-parallelism"
   
   },
   "dependencies": {
@@ -66,6 +67,7 @@
     "@playwright/test": "^1.42.1",
     "@podman-desktop/tests-playwright": "next",
     "@vitest/coverage-v8": "^1.2.1",
+    "cross-env": "7.0.3",
     "electron": "^29.1.4",
     "eslint": "^8.57.0",
     "eslint-import-resolver-custom-alias": "^1.3.2",

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -27,6 +27,15 @@ const PACKAGE_NAME = 'extensions/kube-context';
  * @param {*} packageName package name to appear in test-resources/coverage in project root folder
  * @returns object for code coverage configuration
  */
+
+const excludeArray = [
+  '**/builtin/**',
+  '**/node_modules/**',
+  '**/dist/**',
+  '**/.{idea,git,cache,output,temp,cdix}/**',
+  '**/{.electron-builder,babel,changelog,docusaurus,jest,postcss,prettier,rollup,svelte,tailwind,vite,vitest*,webpack}.config.*',
+];
+
 export function coverageConfig(packageRoot, packageName) {
   const obj = { coverage: {
       all: true,
@@ -50,7 +59,18 @@ export function coverageConfig(packageRoot, packageName) {
   return obj;
 }
 
-export function testConfig() {
+function unitTestConfig() {
+  return {
+    globals: true,
+    include: ['./src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    exclude: excludeArray,
+    // test reporters - default for all and junit for CI
+    reporters: process.env.CI ? ['default', 'junit'] : ['verbose'],
+    outputFile: process.env.CI ? { junit: 'test-resources/output/junit-unit-results.xml' } : {},
+  };
+}
+
+function e2eTestConfig() {
   return {
     globals: true,
     globalSetup: './node_modules/@podman-desktop/tests-playwright/src/globalSetup/global-setup.ts',
@@ -59,14 +79,8 @@ export function testConfig() {
      * By default, vitest search test files in all packages.
      * For e2e tests have sense search only is project root tests folder
      */
-    include: ['**/src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-    exclude: [
-      '**/builtin/**',
-      '**/node_modules/**',
-      '**/dist/**',
-      '**/.{idea,git,cache,output,temp,cdix}/**',
-      '**/{.electron-builder,babel,changelog,docusaurus,jest,postcss,prettier,rollup,svelte,tailwind,vite,vitest*,webpack}.config.*',
-    ],
+    include: ['tests/src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    exclude: excludeArray,
 
     /**
      * A default timeout of 5000ms is sometimes not enough for playwright.
@@ -75,8 +89,12 @@ export function testConfig() {
     hookTimeout: 60_000,
     // test reporters - default for all and junit for CI
     reporters: process.env.CI ? ['default', 'junit'] : ['verbose'],
-    outputFile: process.env.CI ? { junit: 'tests/output/junit-results.xml' } : {},
+    outputFile: process.env.CI ? { junit: 'tests/output/junit-e2e-results.xml' } : {},
   };
+}
+
+export function testConfig() {
+  return process.env.E2E_TESTS ? e2eTestConfig() : unitTestConfig();
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1230,7 +1230,14 @@ core-js-compat@^3.34.0:
   dependencies:
     browserslist "^4.23.0"
 
-cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-env@7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
+cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
Fixes #109.

To test this you can run:
`yarn test` -> runs all unit and e2e tests, creates junit files if env. var. CI=true is set at `test-resources` and `tests/output`.
`yarn test:unit` -> runs unit tests only
`yarn test:e2e` -> run e2e tests only -> for verification purpose, it is enough that you can verify that unit tests are not run, e2e requires some more configuration, so failures are acceptable or see below.

In order to successfully run e2e tests, you need to:
```
git clone podman-desktop
cd podman-desktop
yarn;yarn test:e2e:build
cd ..
cd podman-desktop-redhat-account-ext
yarn
export PODMAN_DESKTOP_ARGS=/path/to/podman-desktop
yarn test:e2e
```
