### PR TITLE
fix: do not ignore errors in podman cli calls

### DIFF
--- a/src/extension.spec.ts
+++ b/src/extension.spec.ts
@@ -24,9 +24,11 @@ import {
   ExtensionContext,
   AuthenticationSession,
   ProgressLocation,
+  configuration,
 } from '@podman-desktop/api';
 import { authentication, commands } from '@podman-desktop/api';
 import * as podmanCli from './podman-cli';
+import { exec } from 'child_process';
 
 vi.mock('@podman-desktop/api', async () => {
   return {
@@ -75,6 +77,16 @@ vi.mock('@podman-desktop/api', async () => {
     StatusBarAlignLeft: 'LEFT',
     ProgressLocation: {
       TASK_WIDGET: 2,
+    },
+    process: {
+      exec: vi.fn(),
+    },
+    configuration: {
+      getConfiguration: () => {
+        return {
+          get: vi.fn(),
+        };
+      }
     },
   };
 });

--- a/src/extension.spec.ts
+++ b/src/extension.spec.ts
@@ -86,7 +86,7 @@ vi.mock('@podman-desktop/api', async () => {
         return {
           get: vi.fn(),
         };
-      }
+      },
     },
   };
 });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -188,13 +188,14 @@ async function isSubscriptionManagerInstalled(): Promise<boolean> {
 }
 
 async function installSubscriptionManger() {
-  const exitCode = await runRpmInstallSubscriptionManager();
-  if (exitCode === undefined) {
-    throw new Error(
-      'Error running podman to install subscription-manager, please make sure podman machine is running!',
-    );
+  try {
+    const exitCode = await runRpmInstallSubscriptionManager();
+  } catch (err) {
+    const exitCode = (err as extensionApi.RunError).exitCode;
+    console.error(`Subscription manager installation returned exit code: ${exitCode}`);
+    TelemetryLogger.logError('subscriptionManagerInstallationError', { error: String(err) });
+    throw err;
   }
-  return exitCode === 0;
 }
 
 async function isPodmanVmSubscriptionActivated() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -179,11 +179,6 @@ async function createOrReuseActivationKey() {
 
 async function isSubscriptionManagerInstalled(): Promise<boolean> {
   const exitCode = await runSubscriptionManager();
-  if (exitCode === undefined) {
-    throw new Error(
-      'Error running podman ssh to detect subscription-manager, please make sure podman machine is running!',
-    );
-  }
   return exitCode === 0;
 }
 
@@ -200,11 +195,6 @@ async function installSubscriptionManger() {
 
 async function isPodmanVmSubscriptionActivated() {
   const exitCode = await runSubscriptionManagerActivationStatus();
-  if (exitCode === undefined) {
-    throw new Error(
-      'Error running subscription-manager in podman machine to get subscription status, please make sure podman machine is running!',
-    );
-  }
   return exitCode === 0;
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -192,7 +192,7 @@ async function installSubscriptionManger() {
     const exitCode = await runRpmInstallSubscriptionManager();
   } catch (err) {
     const exitCode = (err as extensionApi.RunError).exitCode;
-    console.error(`Subscription manager installation returned exit code: ${exitCode}`);
+    console.error(`Subscription manager installation failed. ${String(err)}`);
     TelemetryLogger.logError('subscriptionManagerInstallationError', { error: String(err) });
     throw err;
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -184,9 +184,8 @@ async function isSubscriptionManagerInstalled(): Promise<boolean> {
 
 async function installSubscriptionManger() {
   try {
-    const exitCode = await runRpmInstallSubscriptionManager();
+    return await runRpmInstallSubscriptionManager();
   } catch (err) {
-    const exitCode = (err as extensionApi.RunError).exitCode;
     console.error(`Subscription manager installation failed. ${String(err)}`);
     TelemetryLogger.logError('subscriptionManagerInstallationError', { error: String(err) });
     throw err;

--- a/src/podman-cli.ts
+++ b/src/podman-cli.ts
@@ -18,7 +18,6 @@
 import { isMac, isWindows } from './util';
 import * as extensionApi from '@podman-desktop/api';
 import { TelemetryLogger } from './extension';
-import { error } from 'console';
 
 const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin';
 

--- a/src/podman-cli.ts
+++ b/src/podman-cli.ts
@@ -115,7 +115,7 @@ export async function runSubscriptionManagerRegister(
     return await extensionApi.process.exec(getPodmanCli(), PODMAN_COMMANDS.SM_ACTIVATE_SUBS(activationKeyName, orgId));
   } catch (err) {
     const exitCode = (err as extensionApi.RunError).exitCode;
-    console.error(`Subscription manager registration returned exit code: ${exitCode}`);
+    console.error(`Subscription manager registration failed. ${String(err)}`);
     TelemetryLogger.logError('subscriptionManagerRegisterError', { error: String(err) });
     throw err;
   }
@@ -127,7 +127,7 @@ export async function runSubscriptionManagerUnregister(): Promise<number | undef
     return 0;
   } catch (err) {
     const exitCode = (err as extensionApi.RunError).exitCode;
-    console.error(`Subscription manager registration returned exit code: ${exitCode}`);
+    console.error(`Subscription manager unregister failed. ${String(err)}`);
     TelemetryLogger.logError('subscriptionManagerUnregisterError', { error: String(err) });
     return exitCode;
   }
@@ -139,7 +139,7 @@ export async function runCreateFactsFile(jsonText: string): Promise<number> {
     return 0;
   } catch (err) {
     const exitCode = (err as extensionApi.RunError).exitCode;
-    console.error(`Writing /etc/rhsm/facts/podman-desktop-redhat-account-ext.facts returned exit code: ${exitCode}`);
+    console.error(`Writing /etc/rhsm/facts/podman-desktop-redhat-account-ext.facts failed. ${String(err)}`);
     TelemetryLogger.logError('subscriptionManagerCreateFactsFileError', { error: String(err) });
     throw err;
   }

--- a/src/podman-cli.ts
+++ b/src/podman-cli.ts
@@ -90,16 +90,8 @@ export async function runSubscriptionManager(): Promise<number | undefined> {
   }
 }
 
-export async function runRpmInstallSubscriptionManager(): Promise<number | undefined> {
-  try {
-    await extensionApi.process.exec(getPodmanCli(), PODMAN_COMMANDS.RPM_INSTALL_SM());
-    return 0;
-  } catch (err) {
-    const exitCode = (err as extensionApi.RunError).exitCode;
-    console.error(`Subscription manager installation returned exit code: ${exitCode}`);
-    TelemetryLogger.logError('subscriptionManagerInstallationError', { error: String(err) });
-    return exitCode;
-  }
+export async function runRpmInstallSubscriptionManager(): Promise<extensionApi.RunResult> {
+  return await extensionApi.process.exec(getPodmanCli(), PODMAN_COMMANDS.RPM_INSTALL_SM());
 }
 
 export async function runSubscriptionManagerActivationStatus(): Promise<number | undefined> {
@@ -118,18 +110,14 @@ export async function runSubscriptionManagerActivationStatus(): Promise<number |
 export async function runSubscriptionManagerRegister(
   activationKeyName: string,
   orgId: string,
-): Promise<number | undefined> {
+): Promise<extensionApi.RunResult> {
   try {
-    const result = await extensionApi.process.exec(
-      getPodmanCli(),
-      PODMAN_COMMANDS.SM_ACTIVATE_SUBS(activationKeyName, orgId),
-    );
-    return 0;
+    return await extensionApi.process.exec(getPodmanCli(), PODMAN_COMMANDS.SM_ACTIVATE_SUBS(activationKeyName, orgId));
   } catch (err) {
     const exitCode = (err as extensionApi.RunError).exitCode;
     console.error(`Subscription manager registration returned exit code: ${exitCode}`);
     TelemetryLogger.logError('subscriptionManagerRegisterError', { error: String(err) });
-    return exitCode;
+    throw err;
   }
 }
 
@@ -153,7 +141,7 @@ export async function runCreateFactsFile(jsonText: string): Promise<number> {
     const exitCode = (err as extensionApi.RunError).exitCode;
     console.error(`Writing /etc/rhsm/facts/podman-desktop-redhat-account-ext.facts returned exit code: ${exitCode}`);
     TelemetryLogger.logError('subscriptionManagerCreateFactsFileError', { error: String(err) });
-    return exitCode;
+    throw err;
   }
 }
 

--- a/src/podman-cli.ts
+++ b/src/podman-cli.ts
@@ -121,22 +121,23 @@ export async function runSubscriptionManagerRegister(
   }
 }
 
-export async function runSubscriptionManagerUnregister(): Promise<number | undefined> {
+export async function runSubscriptionManagerUnregister(): Promise<extensionApi.RunResult> {
   try {
-    const result = await extensionApi.process.exec(getPodmanCli(), PODMAN_COMMANDS.SM_DEACTIVATE_SUBS());
-    return 0;
+    return await extensionApi.process.exec(getPodmanCli(), PODMAN_COMMANDS.SM_DEACTIVATE_SUBS());
   } catch (err) {
     const exitCode = (err as extensionApi.RunError).exitCode;
     console.error(`Subscription manager unregister failed. ${String(err)}`);
     TelemetryLogger.logError('subscriptionManagerUnregisterError', { error: String(err) });
-    return exitCode;
+    throw err;
   }
 }
 
-export async function runCreateFactsFile(jsonText: string): Promise<number> {
+export async function runCreateFactsFile(jsonText: string): Promise<extensionApi.RunResult> {
   try {
-    await extensionApi.process.exec(getPodmanCli(), PODMAN_COMMANDS.CREATE_FACTS_FILE(jsonText.replace('\n', '\\n')));
-    return 0;
+    return await extensionApi.process.exec(
+      getPodmanCli(),
+      PODMAN_COMMANDS.CREATE_FACTS_FILE(jsonText.replace('\n', '\\n')),
+    );
   } catch (err) {
     const exitCode = (err as extensionApi.RunError).exitCode;
     console.error(`Writing /etc/rhsm/facts/podman-desktop-redhat-account-ext.facts failed. ${String(err)}`);


### PR DESCRIPTION
Fix #116.
Some problems does not get reported. For example on windows when trying to install subscription manager on old podman vm where there is no rpm-tree cli tool , `runInstallSubscriptionMangaer' is not going to report exception and login is shown as successful, but the subscription-managre is not installed and error is not reported.