### PR TITLE
fix: break cycle in dependencies

### DIFF
--- a/src/extension.spec.ts
+++ b/src/extension.spec.ts
@@ -16,19 +16,18 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { beforeAll, beforeEach, expect, suite, test, vi } from 'vitest';
-import { TelemetryLogger as ExtensionTelemetryLogger, activate } from './extension';
+import { beforeEach, expect, suite, test, vi } from 'vitest';
+import { activate } from './extension';
 import {
   AuthenticationGetSessionOptions,
   TelemetryLogger,
   ExtensionContext,
   AuthenticationSession,
   ProgressLocation,
-  configuration,
 } from '@podman-desktop/api';
 import { authentication, commands } from '@podman-desktop/api';
 import * as podmanCli from './podman-cli';
-import { exec } from 'child_process';
+import { ExtensionTelemetryLogger } from './telemetry';
 
 vi.mock('@podman-desktop/api', async () => {
   return {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,8 +37,7 @@ import {
 import { SubscriptionManagerClient } from '@redhat-developer/rhsm-client';
 import { isLinux } from './util';
 import { SSOStatusBarItem } from './status-bar-item';
-
-export const TelemetryLogger = extensionApi.env.createTelemetryLogger();
+import { ExtensionTelemetryLogger as TelemetryLogger } from './telemetry';
 
 let authenticationServicePromise: Promise<RedHatAuthenticationService>;
 let currentSession: extensionApi.AuthenticationSession | undefined;

--- a/src/podman-cli.ts
+++ b/src/podman-cli.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 import { isMac, isWindows } from './util';
 import * as extensionApi from '@podman-desktop/api';
-import { TelemetryLogger } from './extension';
+import { ExtensionTelemetryLogger as TelemetryLogger } from './telemetry';
 
 const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin';
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,0 +1,21 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { env } from '@podman-desktop/api';
+
+export const ExtensionTelemetryLogger = env.createTelemetryLogger();


### PR DESCRIPTION
PR breaks cycle in deps introduced with shared telemetry logger instance between podman-cli and extension.