### PR TITLE
fix: prep for v1.0.1 build, update version to 1.0.1 and podman-desktop/api to 1.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ The Podman Desktop Red Hat Account Extension puts the [Red Hat Developers Subscr
 
 Once installed, you can find the extension in the Settings menu which you can find in the bottom left corner of Podman Desktop.  To sign into your Red Hat account, open the Authentication menu and click on the "Sign in" button:
 
-![image](https://raw.githubusercontent.com/redhat-developer/podman-desktop-redhat-account-ext/v1.0.0/screenshots/authentication-menu.png)
+![image](https://raw.githubusercontent.com/redhat-developer/podman-desktop-redhat-account-ext/v1.0.1/screenshots/authentication-menu.png)
 
 To sign into your Red Had account, Podman Desktop will open Red Hat SSO in your browser of choice.  The SSO form will make sure that each user has accepted the terms and conditions, and has a valid Red Hat [developers subscription](https://developers.redhat.com/about?source=sso). If needed, you may also create a new Red Hat account and further use social login via an existing Google, Microsoft or GitHub account:
 
-![image](https://raw.githubusercontent.com/redhat-developer/podman-desktop-redhat-account-ext/v0.0.2/screenshots/sso.png)
+![image](https://raw.githubusercontent.com/redhat-developer/podman-desktop-redhat-account-ext/v1.0.1/screenshots/sso.png)
 
 Once signed in, there is nothing further to be done. Podman Desktop will automatically use the SSO token to log into the Red Hat container registry and to register the Linux virtual machine (i.e., podman machine) via subscription-manager. The two tasks are listed in the Tasks menu which you can open on the bottom right of Podman Desktop:
 
-![image](https://raw.githubusercontent.com/redhat-developer/podman-desktop-redhat-account-ext/v1.0.0/screenshots/tasks.png)
+![image](https://raw.githubusercontent.com/redhat-developer/podman-desktop-redhat-account-ext/v1.0.1/screenshots/tasks.png)
 
 To verify that the sign-in process was successful, you may build the following Dockerfile:
 ```Dockerfile
@@ -25,7 +25,7 @@ RUN  dnf install -y kernel
 Pulling the container image `registry.redhat.io/rhel9/toolbox` requires having logged into the Red Hat container registry.  Installing the `kernel` package requires access to protected content.
 
 Once signed in, you can now see being logged into the Red Hat Container Registry `registry.redhat.io` in the Registries menu:
-![image](https://raw.githubusercontent.com/redhat-developer/podman-desktop-redhat-account-ext/v1.0.0/screenshots/registries.png)
+![image](https://raw.githubusercontent.com/redhat-developer/podman-desktop-redhat-account-ext/v1.0.1/screenshots/registries.png)
 
 ## Usage on Linux
 
@@ -37,4 +37,4 @@ From a technical perspective, the extension is not required when running on Linu
 
 You can install the Red Hat Account Extension directly inside of Podman Desktop.  It is also part of the Red Hat Extension Pack:
 
-![image](https://raw.githubusercontent.com/redhat-developer/podman-desktop-redhat-account-ext/main/screenshots/installation.png)
+![image](https://raw.githubusercontent.com/redhat-developer/podman-desktop-redhat-account-ext/v1.0.1/screenshots/installation.png)

--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "redhat-authentication",
   "displayName": "Red Hat Authentication",
   "description": "Login to Red Hat Developers",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "icon": "icon.png",
   "publisher": "redhat",
   "license": "Apache-2.0",
   "engines": {
-    "podman-desktop": "^1.9.0"
+    "podman-desktop": "^1.10.0"
   },
   "main": "./dist/extension.js",
   "contributes": {
@@ -46,7 +46,7 @@
   
   },
   "dependencies": {
-    "@podman-desktop/api": "^1.9.0",
+    "@podman-desktop/api": "^1.10.0",
     "@redhat-developer/rhcra-client": "^0.0.1",
     "@redhat-developer/rhsm-client": "^0.0.4",
     "axios": "^1.6.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -329,10 +329,10 @@
   dependencies:
     playwright "1.43.1"
 
-"@podman-desktop/api@^1.9.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@podman-desktop/api/-/api-1.10.0.tgz#95da399a8173276d79f94b8ef79e1e608095bd41"
-  integrity sha512-zZeCQ2BQ59Own3WmFJqSImOIX9KA+QzwLUOAHN7Dtc4c993D5Qy4xT69FF8ZG2oWxP76dnf4OSoFz+z+Py57lg==
+"@podman-desktop/api@^1.10.0":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@podman-desktop/api/-/api-1.10.1.tgz#0010a752be0df97278ea5a48a7edf87128ec0ba5"
+  integrity sha512-uQrvi1Z6czj5hPPKt2j22Gpj9NDHHt9SzBMs5OZgMRxdWPmrBulCjs6RLbhkZ4CPe64/dn78WlefVVwPB9zk5g==
 
 "@podman-desktop/tests-playwright@next":
   version "0.0.202404252132-654b227"


### PR DESCRIPTION
Prepare for 1.0.1 release build:
1. Version updated to 1.0.1
2. Version of podman-desktop/api updated to 1.10.0
3. Links to images updated to use v1.0.1 tag direct links