### PR TITLE
fix: long activation time

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -307,6 +307,7 @@ export async function activate(context: extensionApi.ExtensionContext): Promise<
 
   // build and initialize auth service and update status bar state
   authenticationServicePromise = buildAndInitializeAuthService(context, statusBarItem);
+
   context.subscriptions.push(
     extensionApi.registry.suggestRegistry({
       name: 'Red Hat Container Registry',
@@ -354,7 +355,7 @@ export async function activate(context: extensionApi.ExtensionContext): Promise<
     }
   });
 
-  await signIntoRedHatDeveloperAccount(false);
+  signIntoRedHatDeveloperAccount(false).catch(console.log);
 
   context.subscriptions.push(providerDisposable);
 


### PR DESCRIPTION
Fix #142 by creating authentication request asyncronously and delaying openid-client ininialization until first authentication request or token refresh.

```
VM5:62 main ↪️ Activating extension (redhat.redhat-authentication) ended in 264 milliseconds
VM5:62 main ↪️ Activating extension (podman-desktop.docker) ended in 227 milliseconds
VM5:62 main ↪️ Activating extension (podman-desktop.lima) ended in 101 milliseconds
VM5:62 main ↪️ Activating extension (podman-desktop.registries) ended in 60 milliseconds
VM5:62 main ↪️ Activating extension (podman-desktop.compose) ended in 246 milliseconds
VM5:62 main ↪️ Activating extension (podman-desktop.kube-context) ended in 203 milliseconds
VM5:62 main ↪️ Activating extension (podman-desktop.kind) ended in 286 milliseconds
VM5:62 main ↪️ Activating extension (podman-desktop.kubectl-cli) ended in 1219 milliseconds
VM5:62 main ↪️ Activating extension (podman-desktop.minikube) ended in 1142 milliseconds
VM5:62 main ↪️ Activating extension (podman-desktop.podman) ended in 1532 milliseconds
```