### PR TITLE
chore(ci): add PR check e2e linux workflow

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -85,3 +85,96 @@ jobs:
 
       - name: Run unit tests
         run: yarn test
+
+  e2e-tests:
+    name: e2e tests
+    runs-on: ubuntu-24.04
+    needs: test
+    env:
+      SKIP_INSTALLATION: true
+    steps:
+      - uses: actions/checkout@v4
+        with: 
+          path: podman-desktop-redhat-account-ext
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      
+      # Checkout podman desktop
+      - uses: actions/checkout@v4
+        with:
+          repository: containers/podman-desktop
+          ref: main
+          path: podman-desktop
+
+      - name: Update podman
+        run: |
+          # ubuntu version from kubic repository to install podman we need (v5)
+          ubuntu_version='23.04'
+          sudo sh -c "echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list"
+          curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key" | sudo apt-key add -
+          # install necessary dependencies for criu package which is not part of 23.04
+          sudo apt-get install -qq libprotobuf32t64 python3-protobuf libnet1
+          # install criu manually from static location
+          curl -sLO http://cz.archive.ubuntu.com/ubuntu/pool/universe/c/criu/criu_3.16.1-2_amd64.deb && sudo dpkg -i criu_3.16.1-2_amd64.deb
+          sudo apt-get update -qq
+          sudo apt-get -qq -y install podman || { echo "Start fallback steps for podman nightly installation from a static mirror" && \
+            sudo sh -c "echo 'deb http://ftp.lysator.liu.se/pub/opensuse/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list" && \
+            curl -L "http://ftp.lysator.liu.se/pub/opensuse/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key" | sudo apt-key add - && \
+            sudo apt-get update && \
+            sudo apt-get -y install podman; }
+          podman version
+
+      - name: Revert unprivileged user namespace restrictions in Ubuntu 24.04
+        run: |
+          # allow unprivileged user namespace
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: Build Podman Desktop for E2E tests
+        working-directory: ./podman-desktop
+        run: |
+          yarn --frozen-lockfile
+          yarn test:e2e:build
+
+      - name: Get yarn cache directory path
+        working-directory: ./podman-desktop-redhat-account-ext
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> ${GITHUB_OUTPUT}
+
+      - uses: actions/cache@v4
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Ensure getting current HEAD version of the test framework
+        working-directory: ./podman-desktop-redhat-account-ext
+        run: yarn add -D @podman-desktop/tests-playwright@next 
+
+      - name: Execute yarn in SSO Extension
+        working-directory: ./podman-desktop-redhat-account-ext
+        run: yarn --frozen-lockfile
+      
+      - name: Build SSO extension from container file
+        working-directory: ./podman-desktop-redhat-account-ext
+        run: |
+          yarn build
+          podman build -t local_sso_image ./
+          CONTAINER_ID=$(podman create localhost/local_sso_image --entrypoint "")
+          podman export $CONTAINER_ID > /tmp/local_sso_image.tar
+          mkdir -p tests/output/sso-tests-pd/plugins
+          tar -xf /tmp/local_sso_image.tar -C tests/output/sso-tests-pd/plugins/
+          
+      - name: Run All E2E tests
+        working-directory: ./podman-desktop-redhat-account-ext
+        env:
+          PODMAN_DESKTOP_ARGS: ${{ github.workspace }}/podman-desktop
+        run: yarn test:e2e
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: e2e-tests
+          path: ./**/tests/output/

--- a/tests/src/sso-extension.spec.ts
+++ b/tests/src/sso-extension.spec.ts
@@ -34,14 +34,14 @@ const extensionLabelName = 'redhat-authentication';
 const authProviderName = 'Red Hat SSO';
 const activeExtensionStatus = 'ACTIVE';
 const disabledExtensionStatus = 'DISABLED';
-
+const skipInstallation = process.env.SKIP_INSTALLATION ? process.env.SKIP_INSTALLATION : false;
 
 beforeEach<RunnerTestContext>(async ctx => {
   ctx.pdRunner = pdRunner;
 });
 
 beforeAll(async () => {
-  pdRunner = new PodmanDesktopRunner();
+  pdRunner = new PodmanDesktopRunner({ customFolder: 'sso-tests-pd', autoUpdate: false, autoCheckUpdate: false });
   page = await pdRunner.start();
   pdRunner.setVideoAndTraceName('sso-e2e');
 
@@ -64,7 +64,8 @@ describe('Red Hat Authentication extension verification', async () => {
     }
   });
 
-  test.runIf(extensionInstalled)(
+  // we want to skip removing of the extension when we are running tests from PR check
+  test.runIf(extensionInstalled && !skipInstallation)(
     'Uninstalled previous version of sso extension',
     async () => {
       await removeExtension();
@@ -72,7 +73,7 @@ describe('Red Hat Authentication extension verification', async () => {
     60000,
   );
 
-  test('Extension can be installed using OCI image', async () => {
+  test.runIf(!skipInstallation)('Extension can be installed using OCI image', async () => {
     const extensions = await navBar.openExtensions();
     await extensions.installExtensionFromOCIImage(imageName);
     await playExpect(extensionCard.card).toBeVisible();

--- a/tests/src/sso-extension.spec.ts
+++ b/tests/src/sso-extension.spec.ts
@@ -81,7 +81,9 @@ describe('Red Hat Authentication extension verification', async () => {
 
   test('Extension card is present and active', async () => {
     const extensions = await navBar.openExtensions();
-    playExpect(await extensions.extensionIsInstalled(extensionLabel)).toBeTruthy();
+    await playExpect.poll(async () => 
+      await extensions.extensionIsInstalled(extensionLabel), { timeout: 30000 }
+    ).toBeTruthy();
     const extensionCard = await extensions.getInstalledExtension(extensionLabelName, extensionLabel);
     await playExpect(extensionCard.status).toHaveText(activeExtensionStatus);
   });


### PR DESCRIPTION
Fixed #93. 

Add PR check job that build extension locally and use it when running e2e tests. Encouraging shift-left workflow.