### PR TITLE
fix(ci): use correct glob pattern to e2e test artifacts

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -126,4 +126,4 @@ jobs:
         if: always()
         with:
           name: e2e-tests
-          path: ./tests/**/output/
+          path: ./**/tests/**/output/

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -155,4 +155,4 @@ jobs:
         if: always()
         with:
           name: e2e-tests
-          path: ./tests/**/output/
+          path: ./**/tests/**/output/

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   reporter: [
     ['list'],
     ['junit', { outputFile: 'tests/output/junit-results.xml' }],
-    ['json', { outputFile: 'tess/output/json-results.json' }],
+    ['json', { outputFile: 'tests/output/json-results.json' }],
     ['html', { open: 'never', outputFolder: 'tests/output/html-results/' }],
   ],
 


### PR DESCRIPTION
Fixes #297. Use correct glob pattern to get test artifacts.