### PR TITLE
chore(ci): add e2e test job that runs against production podman desktop

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -209,15 +209,15 @@ jobs:
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
       - name: Build Podman Desktop for E2E tests locally in production mode
+        working-directory: ./podman-desktop
         env:
           ELECTRON_ENABLE_INSPECT: true
-        working-directory: ./podman-desktop
         run: |
           pnpm install --frozen-lockfile
-          pnpm compile:current
-          $path=$(realpah ./dist/linux-unpacked/podman-desktop)
-          echo $path
-          echo ("PODMAN_DESKTOP_BINARY=" + $path) >> $env:GITHUB_ENV
+          pnpm compile:current --linux dir
+          path=$(realpath ./dist/linux-unpacked/podman-desktop)
+          echo "Podman Desktop built binary: $path"
+          echo "PODMAN_DESKTOP_BINARY_PATH=$path" >> $GITHUB_ENV
 
       - name: Ensure getting current HEAD version of the test framework
         working-directory: ./podman-desktop-redhat-account-ext
@@ -243,8 +243,9 @@ jobs:
           
       - name: Run All E2E tests
         working-directory: ./podman-desktop-redhat-account-ext
+        env:
+          PODMAN_DESKTOP_BINARY: ${{ env.PODMAN_DESKTOP_BINARY_PATH }}
         run: |
-          echo "${{ env.PODMAN_DESKTOP_BINARY }}"
           pnpm test:e2e
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -156,3 +156,99 @@ jobs:
         with:
           name: e2e-tests
           path: ./tests/**/output/
+
+  e2e-tests-production:
+    name: e2e tests production mode
+    runs-on: ubuntu-24.04
+    needs: test
+    env:
+      SKIP_INSTALLATION: true
+    steps:
+      - uses: actions/checkout@v4
+        with: 
+          path: podman-desktop-redhat-account-ext
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
+          package_json_file: ./podman-desktop-redhat-account-ext/package.json
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      
+      # Checkout podman desktop
+      - uses: actions/checkout@v4
+        with:
+          repository: containers/podman-desktop
+          ref: main
+          path: podman-desktop
+
+      - name: Update podman
+        run: |
+          # ubuntu version from kubic repository to install podman we need (v5)
+          ubuntu_version='23.04'
+          sudo sh -c "echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list"
+          curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key" | sudo apt-key add -
+          # install necessary dependencies for criu package which is not part of 23.04
+          sudo apt-get install -qq libprotobuf32t64 python3-protobuf libnet1
+          # install criu manually from static location
+          curl -sLO http://cz.archive.ubuntu.com/ubuntu/pool/universe/c/criu/criu_3.16.1-2_amd64.deb && sudo dpkg -i criu_3.16.1-2_amd64.deb
+          sudo apt-get update -qq
+          sudo apt-get -qq -y install podman || { echo "Start fallback steps for podman nightly installation from a static mirror" && \
+            sudo sh -c "echo 'deb http://ftp.lysator.liu.se/pub/opensuse/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list" && \
+            curl -L "http://ftp.lysator.liu.se/pub/opensuse/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key" | sudo apt-key add - && \
+            sudo apt-get update && \
+            sudo apt-get -y install podman; }
+          podman version
+
+      - name: Revert unprivileged user namespace restrictions in Ubuntu 24.04
+        run: |
+          # allow unprivileged user namespace
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: Build Podman Desktop for E2E tests locally in production mode
+        env:
+          ELECTRON_ENABLE_INSPECT: true
+        working-directory: ./podman-desktop
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm compile:current
+          $path=$(realpah ./dist/linux-unpacked/podman-desktop)
+          echo $path
+          echo ("PODMAN_DESKTOP_BINARY=" + $path) >> $env:GITHUB_ENV
+
+      - name: Ensure getting current HEAD version of the test framework
+        working-directory: ./podman-desktop-redhat-account-ext
+        run: |
+          # workaround for https://github.com/containers/podman-desktop-extension-bootc/issues/712
+          version=$(npm view @podman-desktop/tests-playwright@next version)
+          echo "Version of @podman-desktop/tests-playwright to be used: $version"
+          jq --arg version "$version" '.devDependencies."@podman-desktop/tests-playwright" = $version' package.json > package.json_tmp && mv package.json_tmp package.json
+
+      - name: Execute pnpm in SSO Extension
+        working-directory: ./podman-desktop-redhat-account-ext
+        run: pnpm install --no-frozen-lockfile
+      
+      - name: Build SSO extension from container file
+        working-directory: ./podman-desktop-redhat-account-ext
+        run: |
+          pnpm build
+          podman build -t local_sso_image ./
+          CONTAINER_ID=$(podman create localhost/local_sso_image --entrypoint "")
+          podman export $CONTAINER_ID > /tmp/local_sso_image.tar
+          mkdir -p tests/output/sso-tests-pd/plugins
+          tar -xf /tmp/local_sso_image.tar -C tests/output/sso-tests-pd/plugins/
+          
+      - name: Run All E2E tests
+        working-directory: ./podman-desktop-redhat-account-ext
+        run: |
+          echo "${{ env.PODMAN_DESKTOP_BINARY }}"
+          pnpm test:e2e
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: e2e-tests-production
+          path: ./**/tests/**/output/

--- a/tests/src/sso-extension.spec.ts
+++ b/tests/src/sso-extension.spec.ts
@@ -87,12 +87,12 @@ test.describe.serial('Red Hat Authentication extension verification', () => {
       const details = new SSOExtensionPage(page);
       await playExpect(details.heading).toBeVisible();
       await playExpect(details.status).toHaveText(activeExtensionStatus);
-      const tabs = details.page.getByRole('region', { name: 'Tabs' });
-      const errorTab = tabs.getByRole('button', { name: 'Error' });
+      const errorTab = details.tabs.getByRole('button', { name: 'Error' });
       // we would like to propagate the error's stack trace into test failure message
       let stackTrace = '';
       if ((await errorTab.count()) > 0) {
-        stackTrace = await errorTab.innerText();
+        await details.activateTab('Error');
+        stackTrace = await details.errorStackTrace.innerText();
       }
       await playExpect(errorTab, `Error Tab was present with stackTrace: ${stackTrace}`).not.toBeVisible();
     });

--- a/tests/src/sso-extension.spec.ts
+++ b/tests/src/sso-extension.spec.ts
@@ -46,6 +46,7 @@ test.afterAll(async ({ runner }) => {
 
 test.describe.serial('Red Hat Authentication extension verification', () => {
   test.describe.serial('Red Hat Authentication extension installation', () => {
+    // PR check builds extension locally and so it is available already
     test('Go to extensions and check if extension is already installed', async ({ navigationBar }) => {
       const extensions = await navigationBar.openExtensions();
       if (await extensions.extensionIsInstalled(extensionLabel)) {
@@ -54,12 +55,14 @@ test.describe.serial('Red Hat Authentication extension verification', () => {
     });
 
     // we want to skip removing of the extension when we are running tests from PR check
-    test('Uninstalle previous version of sso extension', async ({ navigationBar }) => {
+    test('Uninstall previous version of sso extension', async ({ navigationBar }) => {
       test.skip(!extensionInstalled || !!skipInstallation);
       test.setTimeout(60000);
       await removeExtension(navigationBar);
     });
 
+    // we want to install extension from OCI image (usually using latest tag) after new code was added to the codebase
+    // and extension was published already
     test('Extension can be installed using OCI image', async ({ navigationBar }) => {
       test.skip(extensionInstalled && !skipInstallation);
       test.setTimeout(200000);
@@ -68,7 +71,7 @@ test.describe.serial('Red Hat Authentication extension verification', () => {
       await playExpect(extensionCard.card).toBeVisible();
     });
 
-    test('Extension card is present and active', async ({ navigationBar }) => {
+    test('Extension (card) is installed, present and active', async ({ navigationBar }) => {
       const extensions = await navigationBar.openExtensions();
       await playExpect.poll(async () => 
         await extensions.extensionIsInstalled(extensionLabel), { timeout: 30000 },
@@ -77,13 +80,21 @@ test.describe.serial('Red Hat Authentication extension verification', () => {
       await playExpect(extensionCard.status).toHaveText(activeExtensionStatus);
     });
 
-    test('Extension Details show correct status', async ({ page,navigationBar }) => {
+    test('Extension\'s details show correct status, no error', async ({ page,navigationBar }) => {
       const extensions = await navigationBar.openExtensions();
       const extensionCard = await extensions.getInstalledExtension(extensionLabelName, extensionLabel);
       await extensionCard.openExtensionDetails('Red Hat Authentication');
       const details = new SSOExtensionPage(page);
       await playExpect(details.heading).toBeVisible();
       await playExpect(details.status).toHaveText(activeExtensionStatus);
+      const tabs = details.page.getByRole('region', { name: 'Tabs' });
+      const errorTab = tabs.getByRole('button', { name: 'Error' });
+      // we would like to propagate the error's stack trace into test failure message
+      let stackTrace = '';
+      if ((await errorTab.count()) > 0) {
+        stackTrace = await errorTab.innerText();
+      }
+      await playExpect(errorTab, `Error Tab was present with stackTrace: ${stackTrace}`).not.toBeVisible();
     });
 
     test('SSO provider is available in Authentication Page', async ({ navigationBar }) => {


### PR DESCRIPTION
Fixed #299.

PR check now has two e2e jobs.