### PR TITLE
chore(ci): update windows e2e tests workflow

### DIFF
--- a/.github/workflows/sso-e2e-nightly-windows.yaml
+++ b/.github/workflows/sso-e2e-nightly-windows.yaml
@@ -1,12 +1,13 @@
 name: Podman Desktop SSO E2E Nightly
 
 on:
-  schedule:
-    - cron:  '0 4 * * *'
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       fork:
-        default: 'containers'
+        default: 'podman-desktop'
         description: 'Podman Desktop repo fork'
         type: string
         required: true
@@ -31,8 +32,8 @@ on:
         type: string
         required: true
       podman_remote_url:
-        default: 'https://github.com/containers/podman/releases/download/v5.1.1/podman-remote-release-windows_amd64.zip'
-        description: 'podman remote zip'
+        default: 'https://github.com/containers/podman/releases/download/v5.3.1/podman-5.3.1-setup.exe''
+        description: 'podman setup exe'
         type: string
         required: true
       podman_options:
@@ -45,27 +46,24 @@ on:
         description: 'Env. Variables passed into target machine, ie: VAR1=xxx,VAR2=true,VAR3=15,VAR4="Pass me along"'
         type: 'string'
         required: true
+      podman_provider:
+        default: 'wsl'
+        description: 'Podman virtualization provider'
+        type: 'string'
+        required: true
 
 jobs:
   windows:
     name: windows-${{ matrix.windows-version }}-${{ matrix.windows-featurepack }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      checks: write
     env:
-      QENVS_VERSION: v0.6.3
+      MAPT_VERSION: v0.7.2
+      MAPT_IMAGE: quay.io/redhat-developer/mapt
     strategy:
       fail-fast: false
       matrix:
-        windows-version: ['10','11']
-        windows-featurepack: ['22h2-ent', '23h2-ent']
-        exclude:
-        - windows-version: '10'
-          windows-featurepack: '23h2-ent'
-        - windows-version: '11'
-          windows-featurepack: '22h2-ent'
-
+        windows-version: ['11']
+        windows-featurepack: ['24h2-ent']
 
     steps:
     - name: Get Podman version used by Desktop
@@ -75,15 +73,15 @@ jobs:
         echo "PD_PODMAN_VERSION=${version}" >> $GITHUB_ENV
     - name: Set the default env. variables
       env:
-        DEFAULT_FORK: 'containers'
+        DEFAULT_FORK: 'podman-desktop'
         DEFAULT_BRANCH: 'main'
         DEFAULT_EXT_TESTS: '1'
         DEFAULT_NPM_TARGET: 'test:e2e'
         DEFAULT_ENV_VARS: 'TEST_PODMAN_MACHINE=true'
         DEFAULT_PODMAN_OPTIONS: 'INIT=1,START=1,ROOTFUL=1,NETWORKING=0'
         DEFAULT_EXT_REPO_OPTIONS: 'REPO=podman-desktop-redhat-account-ext,FORK=redhat-developer,BRANCH=main'
-        DEFAULT_VERSION: "${{ env.PD_PODMAN_VERSION || '5.1.1' }}"
-        DEFAULT_URL: "https://github.com/containers/podman/releases/download/v$DEFAULT_VERSION/podman-remote-release-windows_amd64.zip"
+        DEFAULT_URL: "https://github.com/containers/podman/releases/download/v$DEFAULT_VERSION/podman-$DEFAULT_VERSION-setup.exe"
+        DEFAULT_IMAGES_VERSIONS: 'BUILDER="v0.0.3",PODMAN="v0.0.3",RUNNER="v0.0.3"'
       run: |
         echo "FORK=${{ github.event.inputs.fork || env.DEFAULT_FORK }}" >> $GITHUB_ENV
         echo "BRANCH=${{ github.event.inputs.branch || env.DEFAULT_BRANCH }}" >> $GITHUB_ENV
@@ -105,14 +103,16 @@ jobs:
           -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
-          quay.io/rhqp/qenvs:${{ env.QENVS_VERSION }} azure \
+          ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION }} azure \
             windows create \
             --project-name 'windows-desktop' \
             --backed-url 'file:///workspace' \
             --conn-details-output '/workspace' \
             --windows-version '${{ matrix.windows-version }}' \
             --windows-featurepack '${{ matrix.windows-featurepack }}' \
-            --vmsize 'Standard_D8s_v4' \
+            --nested-virt \
+            --cpus 8 \
+            --memory 16 \
             --tags project=podman-desktop \
             --spot
         # Check logs 
@@ -140,18 +140,19 @@ jobs:
         # Check logs for the x session
         podman logs x-session
 
-    - name: Download Podman, do not initialize
+    - name: Download Podman nightly, do not initialize and start
       run: |
         podman run --rm -d --name pde2e-podman-run \
           -e TARGET_HOST=$(cat host) \
           -e TARGET_HOST_USERNAME=$(cat username) \
           -e TARGET_HOST_KEY_PATH=/data/id_rsa \
           -e TARGET_FOLDER=pd-e2e \
+          -e TARGET_CLEANUP=false \
           -e TARGET_RESULTS=results \
           -e OUTPUT_FOLDER=/data \
           -e DEBUG=true \
           -v $PWD:/data:z \
-          quay.io/odockal/pde2e-podman:v0.0.1-windows  \
+          quay.io/odockal/pde2e-podman:${{ env.PDE2E_PODMAN }}-windows  \
             pd-e2e/podman.ps1 \
               -downloadUrl ${{ env.PODMAN_URL }} \
               -targetFolder pd-e2e \
@@ -175,7 +176,7 @@ jobs:
           -e OUTPUT_FOLDER=/data \
           -e DEBUG=true \
           -v $PWD:/data:z \
-          quay.io/odockal/pde2e-runner:v0.0.1-windows  \
+          quay.io/odockal/pde2e-runner:${{ env.PDE2E_RUNNER }}-windows \
               pd-e2e/runner.ps1 \
                 -targetFolder pd-e2e \
                 -resultsFolder results \
@@ -205,7 +206,7 @@ jobs:
           -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
-          quay.io/rhqp/qenvs:${{ env.QENVS_VERSION }} azure \
+          ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION }} azure \
             windows destroy \
             --project-name 'windows-desktop' \
             --backed-url 'file:///workspace'
@@ -218,6 +219,7 @@ jobs:
       with:
         fail_on_failure: true
         include_passed: true
+        annotate_only: true
         detailed_summary: true
         require_tests:  true
         report_paths: '**/*results.xml'

--- a/.github/workflows/sso-e2e-nightly-windows.yaml
+++ b/.github/workflows/sso-e2e-nightly-windows.yaml
@@ -79,6 +79,7 @@ jobs:
         DEFAULT_NPM_TARGET: 'test:e2e'
         DEFAULT_ENV_VARS: 'TEST_PODMAN_MACHINE=true'
         DEFAULT_PODMAN_OPTIONS: 'INIT=1,START=1,ROOTFUL=1,NETWORKING=0'
+        DEFAULT_PODMAN_PROVIDER: 'wsl'
         DEFAULT_EXT_REPO_OPTIONS: 'REPO=podman-desktop-redhat-account-ext,FORK=redhat-developer,BRANCH=main'
         DEFAULT_URL: "https://github.com/containers/podman/releases/download/v$DEFAULT_VERSION/podman-$DEFAULT_VERSION-setup.exe"
         DEFAULT_IMAGES_VERSIONS: 'BUILDER="v0.0.3",PODMAN="v0.0.3",RUNNER="v0.0.3"'
@@ -87,6 +88,7 @@ jobs:
         echo "BRANCH=${{ github.event.inputs.branch || env.DEFAULT_BRANCH }}" >> $GITHUB_ENV
         echo "NPM_TARGET=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV
         echo "ENV_VARS=${{ github.event.inputs.env_vars || env.DEFAULT_ENV_VARS }}" >> $GITHUB_ENV
+        echo "PODMAN_PROVIDER=${{ github.event.inputs.podman_provider || env.DEFAULT_PODMAN_PROVIDER }}" >> $GITHUB_ENV
         echo "PODMAN_URL=${{ github.event.inputs.podman_remote_url || env.DEFAULT_URL }}" >> $GITHUB_ENV
         echo "EXT_TESTS=${{ github.event.inputs.ext_tests || env.DEFAULT_EXT_TESTS }}" >> $GITHUB_ENV
         echo "${{ github.event.inputs.podman_options || env.DEFAULT_PODMAN_OPTIONS }}" | awk -F ',' \
@@ -157,6 +159,7 @@ jobs:
               -downloadUrl ${{ env.PODMAN_URL }} \
               -targetFolder pd-e2e \
               -resultsFolder results \
+              -podmanProvider ${{ env.PODMAN_PROVIDER }} \
               -initialize 0 \
               -rootful 0 \
               -start 0 \
@@ -192,6 +195,7 @@ jobs:
                 -rootful ${{ env.PODMAN_ROOTFUL }} \
                 -start ${{ env.PODMAN_START }} \
                 -userNetworking ${{ env.PODMAN_NETWORKING }} \
+                -podmanProvider ${{ env.PODMAN_PROVIDER }} \
                 -envVars ${{ env.ENV_VARS }}
         # check logs
         podman logs -f pde2e-runner-run


### PR DESCRIPTION
Fixed #371.

Notes: Workflow is updated in general. Also, it now does not run on nightly base, but rather on after merge of new PRs.