### PR TITLE
fix: remove additional quote in input param

### DIFF
--- a/.github/workflows/sso-e2e-nightly-windows.yaml
+++ b/.github/workflows/sso-e2e-nightly-windows.yaml
@@ -32,7 +32,7 @@ on:
         type: string
         required: true
       podman_remote_url:
-        default: 'https://github.com/containers/podman/releases/download/v5.3.1/podman-5.3.1-setup.exe''
+        default: 'https://github.com/containers/podman/releases/download/v5.3.1/podman-5.3.1-setup.exe'
         description: 'podman setup exe'
         type: string
         required: true


### PR DESCRIPTION
There is additional quote in input param value and it is breaking the workflow.