### PR TITLE
fix: call podman CLI API with connection parameter

### DIFF
--- a/src/extension.spec.ts
+++ b/src/extension.spec.ts
@@ -117,7 +117,7 @@ suite('signin command telemetry reports', () => {
       },
     );
     vi.spyOn(subscription, 'isRedHatRegistryConfigured').mockResolvedValue(true);
-    vi.spyOn(podmanCli, 'getRunningPodmanMachineName').mockReturnValue(undefined);
+    vi.spyOn(podmanCli, 'getConnectionForRunningPodmanMachine').mockReturnValue(undefined);
     await extension.activate(createExtContext());
     expect(commandFunctionCopy!).toBeDefined();
     await commandFunctionCopy!();
@@ -180,7 +180,7 @@ suite('signin command telemetry reports', () => {
       },
     );
     vi.spyOn(subscription, 'isRedHatRegistryConfigured').mockReturnValue(true);
-    vi.spyOn(podmanCli, 'getRunningPodmanMachineName').mockReturnValue('machine1');
+    vi.spyOn(podmanCli, 'getConnectionForRunningPodmanMachine').mockReturnValue('machine1');
     vi.spyOn(OrganizationService.prototype, 'checkOrgScaCapability').mockResolvedValue({ body: {} });
     await extension.activate(createExtContext());
     expect(commandFunctionCopy!).toBeDefined();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,7 @@ import { SubscriptionManagerClient } from '@redhat-developer/rhsm-client';
 import { onDidChangeSessions, RedHatAuthenticationService } from './authentication-service';
 import { getAuthConfig } from './configuration';
 import {
-  getRunningPodmanMachineName,
+  getConnectionForRunningPodmanMachine,
   runCreateFactsFile,
   runRpmInstallSubscriptionManager,
   runStartPodmanMachine,
@@ -191,7 +191,7 @@ async function isPodmanVmSubscriptionActivated(connection: extensionApi.Provider
 }
 
 async function removeSession(sessionId: string): Promise<void> {
-  const connection = getRunningPodmanMachineName();
+  const connection = getConnectionForRunningPodmanMachine();
   if (connection) {
     runSubscriptionManagerUnregister(connection).catch(console.error); // ignore error in case vm subscription activation failed on login
   }
@@ -255,7 +255,7 @@ async function configureRegistryAndActivateSubscription(): Promise<void> {
           title: 'Activating Red Hat Subscription',
         },
         async () => {
-          const runningConnection = getRunningPodmanMachineName();
+          const runningConnection = getConnectionForRunningPodmanMachine();
           if (!runningConnection) {
             if (isLinux()) {
               await extensionApi.window.showInformationMessage(

--- a/src/podman-cli.ts
+++ b/src/podman-cli.ts
@@ -199,13 +199,13 @@ export async function runStartPodmanMachine(
   );
 }
 
-export function getRunningPodmanMachineName(): podmanDesktopAPI.ProviderContainerConnection | undefined {
+export function getConnectionForRunningPodmanMachine(): podmanDesktopAPI.ProviderContainerConnection | undefined {
   const conns = podmanDesktopAPI.provider.getContainerConnections();
-  const startedVms = conns.filter(
+  const connToRunningVms = conns.filter(
     conn =>
       conn.providerId === 'podman' &&
       conn.connection.status() === 'started' &&
       !conn.connection.endpoint.socketPath.startsWith('/run/user/'),
   );
-  return startedVms.length >= 1 ? startedVms[0] : undefined;
+  return connToRunningVms.length >= 1 ? connToRunningVms[0] : undefined;
 }


### PR DESCRIPTION
This PR is result of verification of https://github.com/podman-desktop/podman-desktop/issues/9860 by using runOptions parameter of execPodman.

Related to #44.