### PR TITLE
fix: missing Red Hat image registry icon

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,14 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { readFileSync } from 'node:fs';
-import path from 'node:path';
-
 import * as extensionApi from '@podman-desktop/api';
 import type { ServiceAccountV1 } from '@redhat-developer/rhcra-client';
 import { ContainerRegistryAuthorizerClient } from '@redhat-developer/rhcra-client';
 import { SubscriptionManagerClient } from '@redhat-developer/rhsm-client';
 
+import icon from '../icon.png';
 import { onDidChangeSessions, RedHatAuthenticationService } from './authentication-service';
 import { getAuthConfig } from './configuration';
 import {
@@ -53,14 +51,6 @@ let currentSession: extensionApi.AuthenticationSession | undefined;
 
 async function getAuthenticationService(): Promise<RedHatAuthenticationService> {
   return authenticationServicePromise;
-}
-
-// function to encode file data to base64 encoded string
-function fileToBase64(file: string): string {
-  // read binary data
-  const bitmap = readFileSync(file);
-  // convert binary data to base64 encoded string
-  return bitmap.toString('base64');
 }
 
 function parseJwt(token: string): JwtToken {
@@ -322,7 +312,7 @@ export async function activate(context: extensionApi.ExtensionContext): Promise<
   context.subscriptions.push(
     extensionApi.registry.suggestRegistry({
       name: 'Red Hat Container Registry',
-      icon: fileToBase64(path.resolve(__dirname, '..', 'icon.png')),
+      icon,
       url: 'registry.redhat.io',
     }),
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,6 @@
     "esModuleInterop": true
   },
   "include": [
-    "src/**/*.ts"
+    "src/**/*.ts", "types/*.d.ts"
   ]
 }

--- a/types/template.d.ts
+++ b/types/template.d.ts
@@ -1,0 +1,22 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+declare module '*.png' {
+  const contents: string;
+  export = contents;
+}


### PR DESCRIPTION
Add png module to load icons using import statement.

Fix #618.