### PR TITLE
fix: use `RHEl Workstation` role instead of `RHEL Server`

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -139,7 +139,7 @@ async function createOrReuseActivationKey(connection: extensionApi.ProviderConta
     // TODO: add check that used role and usage exists in organization
     await client.activationKey.createActivationKeys({
       name: 'podman-desktop',
-      role: 'RHEL Server',
+      role: 'RHEl Workstation',
       usage: 'Development/Test',
       serviceLevel: 'Self-Support',
     });


### PR DESCRIPTION
Using `RHEL Server` causing a BadRequest Error and message that `Organization does not support role provided`. Developers website is now using `RHEl Workstation` role when creating activation keys. This PR updates the code to use correct role.

Fix #636.