### PR TITLE
fix: use new role to create new  subscription activation key

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -138,7 +138,7 @@ async function createOrReuseActivationKey(connection: extensionApi.ProviderConta
     // error is undefined when activation key already exists
     const { error: createKeyErr } = await client.activationKey.createActivationKeys({
       name: 'podman-desktop',
-      role: 'RHEl Workstation',
+      role: 'Red Hat Enterprise Linux Workstation',
       usage: 'Development/Test',
       serviceLevel: 'Self-Support',
     });


### PR DESCRIPTION
Update activation key role name to new one `Red Hat Enterprise Linux Workstation`

Fix #670.