### PR TITLE
fix(ci): fix name of e2e npm target

### DIFF
--- a/.github/workflows/sso-e2e-nightly-windows.yaml
+++ b/.github/workflows/sso-e2e-nightly-windows.yaml
@@ -17,7 +17,7 @@ on:
         type: string
         required: true
       npm_target:
-        default: 'test:e2e:run'
+        default: 'test:e2e'
         description: 'npm target to run tests'
         type: string
         required: true


### PR DESCRIPTION
Fixing the name of the npm target. SSO does not have `test:e2e:run` as podman-desktop does.