### PR TITLE
chore: update windows workflow to use mapt 0.8.2

### DIFF
--- a/.github/workflows/sso-e2e-nightly-windows.yaml
+++ b/.github/workflows/sso-e2e-nightly-windows.yaml
@@ -58,7 +58,7 @@ jobs:
     name: windows-${{ matrix.windows-version }}-${{ matrix.windows-featurepack }}
     runs-on: ubuntu-latest
     env:
-      MAPT_VERSION: v0.8.0
+      MAPT_VERSION: v0.8.2
       MAPT_IMAGE: quay.io/redhat-developer/mapt
     strategy:
       fail-fast: false
@@ -102,11 +102,11 @@ jobs:
     - name: Set the default env. variables
       env:
         DEFAULT_PD_REPO_OPTIONS: 'REPO=podman-desktop,FORK=podman-desktop,BRANCH=main'
-        DEFAULT_NPM_TARGET: 'test:e2e:run'
+        DEFAULT_NPM_TARGET: 'test:e2e'
         DEFAULT_ENV_VARS: 'TEST_PODMAN_MACHINE=true'
         DEFAULT_PODMAN_OPTIONS: 'INIT=1,START=1,ROOTFUL=1,NETWORKING=0'
         DEFAULT_PODMAN_PROVIDER: 'wsl'
-        DEFAULT_VERSION: "${{ env.PD_PODMAN_VERSION || '5.4.0' }}"
+        DEFAULT_VERSION: "${{ env.PD_PODMAN_VERSION || '5.4.2' }}"
         DEFAULT_URL: "https://github.com/containers/podman/releases/download/v$DEFAULT_VERSION/podman-$DEFAULT_VERSION-setup.exe"
         DEFAULT_EXT_REPO_OPTIONS: 'REPO=podman-desktop-redhat-account-ext,FORK=redhat-developer,BRANCH=main,TESTS=1'
         DEFAULT_IMAGES_VERSIONS: 'BUILDER="v0.0.3",PODMAN="v0.0.3",RUNNER="v0.0.3"'


### PR DESCRIPTION
Updates the mapt version. also change default npm target when running nightly builds and update default podman version to 5.4.2.