### PR TITLE
chore(ci): remove setting chromium as default browser

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -145,14 +145,6 @@ jobs:
           jq --arg version "$version" '.devDependencies."@podman-desktop/tests-playwright" = $version' package.json > package.json_tmp && mv package.json_tmp package.json
           pnpm install --no-frozen-lockfile
 
-      - name: Set default browser to Chromium
-        run: |
-          # TODO: Follow up issue: https://github.com/redhat-developer/podman-desktop-redhat-account-ext/issues/727
-          chromiumBrowser=$(which chromium-browser)
-          echo "Path to chromium: ${chromiumBrowser}"
-          sudo update-alternatives --install /usr/bin/x-www-browser x-www-browser $chromiumBrowser 500
-          sudo update-alternatives --set x-www-browser $chromiumBrowser
-
       - name: Run All E2E tests in Red Hat Account Extension in Development Mode
         working-directory: ${{ env.REPOSITORY }}
         if: ${{ env.MODE == 'development' }}


### PR DESCRIPTION
Fixes #737. It removes the section where we set chromium as default browser, since it is causing troubles on CI.