### PR TITLE
Enable Auth. e2e tests with SSO authentication on GHA Ubuntu runner

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -113,10 +113,28 @@ jobs:
             sudo apt-get -y install podman; }
           podman version
 
+      - name: Set default browser desktop app and handlers
+        run: |
+          xdg-settings set default-web-browser firefox.desktop
+          xdg-mime default firefox.desktop x-scheme-handler/https
+          xdg-mime default firefox.desktop x-scheme-handler/http
+          xvfb-run xdg-open 'https://developers.redhat.com/articles/faqs-no-cost-red-hat-enterprise-linux#general' & sleep 5; pkill Xvfb
+
+      # Install dbus-x11 package to allow dbus session for user for particular display (xvfb-maybe used in e2e test)
+      # for reference, similar issue: https://github.com/actions/runner-images/issues/12127
+      - name: Install dbus-x11 package
+        run: sudo apt-get install dbus-x11
+
       - name: Revert unprivileged user namespace restrictions in Ubuntu 24.04
         run: |
           # allow unprivileged user namespace
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: Set Chromium policy for Podman Desktop app redirection from browser
+        run: |
+          echo '{"URLAllowlist": ["podman-desktop:*"]}' > url_allow_list.json
+          sudo mkdir -p /etc/chromium/policies/managed
+          sudo cp url_allow_list.json /etc/chromium/policies/managed/url_allow_list.json
 
       - name: Build Podman Desktop for E2E tests Development Mode
         working-directory: ./podman-desktop
@@ -154,7 +172,9 @@ jobs:
           DVLPR_USERNAME: ${{ secrets.DVLPR_USERNAME }}
           DVLPR_PASSWORD: ${{ secrets.DVLPR_PASSWORD }}
           AUTH_E2E_TESTS: true
-        run: pnpm test:e2e
+        run: |
+          export $(dbus-launch)
+          pnpm test:e2e
 
       - name: Run All E2E tests in Red Hat Account Extension in Production mode
         working-directory: ${{ env.REPOSITORY }}
@@ -164,7 +184,9 @@ jobs:
           DVLPR_USERNAME: ${{ secrets.DVLPR_USERNAME }}
           DVLPR_PASSWORD: ${{ secrets.DVLPR_PASSWORD }}
           AUTH_E2E_TESTS: true
-        run: pnpm test:e2e
+        run: |
+          export $(dbus-launch)
+          pnpm test:e2e
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v5

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "7zip-min": "^2.1.0",
     "@playwright/test": "^1.53.2",
-    "@podman-desktop/tests-playwright": "1.20.0-202507021922-39e1821c503",
+    "@podman-desktop/tests-playwright": "^1.20.0-202507021922-39e1821c503",
     "@types/js-yaml": "^4.0.5",
     "@types/node": "^22",
     "@typescript-eslint/eslint-plugin": "^8.35.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,13 @@ importers:
         specifier: ^1.53.2
         version: 1.53.2
       '@podman-desktop/tests-playwright':
+<<<<<<< HEAD
         specifier: 1.20.0-202507021922-39e1821c503
         version: 1.20.0-202507021922-39e1821c503
+=======
+        specifier: ^1.20.0-202507020851-166ac880eb1
+        version: 1.20.0-202507020851-166ac880eb1
+>>>>>>> 4da95cc (chore(ci,tests): stabilize auth e2e tests with changes on CI and in tests)
       '@types/js-yaml':
         specifier: ^4.0.5
         version: 4.0.9
@@ -572,8 +577,13 @@ packages:
   '@podman-desktop/podman-extension-api@1.19.2':
     resolution: {integrity: sha512-nxeRhLTmYEDPvBX0oSa2RA+89sdyDD/dQEcVTw2FksvDFessk6izhnQfzpzbtAC/Yygrucq8Uczer7EFQzaFHw==}
 
+<<<<<<< HEAD
   '@podman-desktop/tests-playwright@1.20.0-202507021922-39e1821c503':
     resolution: {integrity: sha512-PKC8foeHxIKxobKtKjLUSfWNDGTrhruNKS1AhdBUFNO6sCBFvDnefNLenHc6JyYmOyl3+v9mre10z2/WsQZUuA==}
+=======
+  '@podman-desktop/tests-playwright@1.20.0-202507020851-166ac880eb1':
+    resolution: {integrity: sha512-upDy4Jgp0nQ3u/okRxf7J62eAVezyMK35P75NzyBAb70q5PcLMNgcYuKUVRWCDWyjb+sSKgWQYes9K/of5qGkg==}
+>>>>>>> 4da95cc (chore(ci,tests): stabilize auth e2e tests with changes on CI and in tests)
 
   '@rollup/rollup-android-arm-eabi@4.44.0':
     resolution: {integrity: sha512-xEiEE5oDW6tK4jXCAyliuntGR+amEMO7HLtdSshVuhFnKTYoeYMyXQK7pLouAJJj5KHdwdn87bfHAR2nSdNAUA==}
@@ -981,10 +991,6 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
-  ansi-styles@6.2.1:
-    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
-    engines: {node: '>=12'}
-
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1223,17 +1229,11 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-
   electron-to-chromium@1.5.13:
     resolution: {integrity: sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -2387,10 +2387,6 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
-  string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
-
   string.prototype.trim@1.2.10:
     resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
     engines: {node: '>= 0.4'}
@@ -2722,10 +2718,6 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
-  wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
-
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -3008,11 +3000,11 @@ snapshots:
 
   '@isaacs/cliui@8.0.2':
     dependencies:
-      string-width: 5.1.2
+      string-width: 4.2.3
       string-width-cjs: string-width@4.2.3
       strip-ansi: 7.1.0
       strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
+      wrap-ansi: 7.0.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
   '@istanbuljs/schema@0.1.3': {}
@@ -3094,7 +3086,11 @@ snapshots:
     dependencies:
       '@podman-desktop/api': 1.19.2
 
+<<<<<<< HEAD
   '@podman-desktop/tests-playwright@1.20.0-202507021922-39e1821c503': {}
+=======
+  '@podman-desktop/tests-playwright@1.20.0-202507020851-166ac880eb1': {}
+>>>>>>> 4da95cc (chore(ci,tests): stabilize auth e2e tests with changes on CI and in tests)
 
   '@rollup/rollup-android-arm-eabi@4.44.0':
     optional: true
@@ -3504,8 +3500,6 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
-  ansi-styles@6.2.1: {}
-
   argparse@2.0.1: {}
 
   array-buffer-byte-length@1.0.2:
@@ -3762,13 +3756,9 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  eastasianwidth@0.2.0: {}
-
   electron-to-chromium@1.5.13: {}
 
   emoji-regex@8.0.0: {}
-
-  emoji-regex@9.2.2: {}
 
   error-ex@1.3.2:
     dependencies:
@@ -5121,12 +5111,6 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
-  string-width@5.1.2:
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.1.0
-
   string.prototype.trim@1.2.10:
     dependencies:
       call-bind: 1.0.8
@@ -5483,12 +5467,6 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-
-  wrap-ansi@8.1.0:
-    dependencies:
-      ansi-styles: 6.2.1
-      string-width: 5.1.2
-      strip-ansi: 7.1.0
 
   wrappy@1.0.2: {}
 


### PR DESCRIPTION
Fixes #759.

Mutliple various fixes required to pass auth. sso tests in external browser on GHA CI.

Depends on https://github.com/podman-desktop/podman-desktop/pull/13022.