### PR TITLE
fix: remove comment from bash multiline command as it fails

### DIFF
--- a/.github/workflows/sso-e2e-nightly-windows.yaml
+++ b/.github/workflows/sso-e2e-nightly-windows.yaml
@@ -146,7 +146,6 @@ jobs:
             --memory 16 \
             --tags project=podman-desktop,source=github,org=${{github.repository_owner}},run=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} \
             --spot \
-            # Workaround for https://github.com/redhat-developer/mapt/issues/451
             --spot-excluded-regions southafricawest,australiacentral2,switzerlandwest
         # Check logs 
         podman logs -f windows-create


### PR DESCRIPTION
Removes comment from bash multiline command.