### PR TITLE
feat: add Containerfiles for build

### DIFF
--- a/build/Containerfile
+++ b/build/Containerfile
@@ -1,0 +1,30 @@
+#
+# Copyright (C) 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+FROM ghcr.io/redhat-developer/podman-desktop-redhat-account-ext-builder:next as builder
+
+COPY --chown=1001:root . .
+RUN pnpm install && pnpm build
+
+FROM scratch
+
+LABEL org.opencontainers.image.title="Red Hat Account" \
+  org.opencontainers.image.description="Allows the ability in Podman Desktop to login to Red Hat SSO" \
+  org.opencontainers.image.vendor="Red Hat" \
+  io.podman-desktop.api.version=">= 1.9.0"
+
+COPY --from=builder /opt/app-root/extension-source/builtin/redhat-authentication.cdix /extension

--- a/build/Containerfile.builder
+++ b/build/Containerfile.builder
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+FROM registry.access.redhat.com/ubi10/nodejs-22-minimal@sha256:52f5a9e3eb1191276ef576ad88142a27d4ef61317384f383534526f55761387b
+
+ENV EXTENSION_SRC=/opt/app-root/extension-source
+RUN mkdir -p $EXTENSION_SRC
+WORKDIR $EXTENSION_SRC
+
+COPY pnpm-lock.yaml package.json .
+RUN npm install --global pnpm && \
+    pnpm --frozen-lockfile install


### PR DESCRIPTION
Related to  #1011.

How to use from podman-desktop-redhat-account-ext folder:

1. `$ podman build . -f build/Containerfile.builder -t ghcr.io/redhat-developer/podman-desktop-redhat-account-ext-builder:next`
2. `$ podman build . -f build/Containerfile -t ghcr.io/redhat-developer/podman-desktop-redhat-account-ext:next`
3. `$ podman create --name extension-sso ghcr.io/redhat-developer/podman-desktop-redhat-account-ext:next`
4. `$ mkdir tmp`
5. `$ podman cp extension-sso:/extension tmp`

How to check results:

```
ls -l tmp/extension tmp/extension/dist
tmp/extension:
total 56
drwxr-xr-x@ 4 eskimo  staff    128 Dec  9 15:59 dist
-rw-r--r--@ 1 eskimo  staff   1437 Dec  9 15:59 icon.png
-rw-r--r--@ 1 eskimo  staff  11358 Dec  9 15:59 LICENSE
-rw-r--r--@ 1 eskimo  staff   3839 Dec  9 15:59 package.json
-rw-r--r--@ 1 eskimo  staff   3619 Dec  9 15:59 README.md
-rw-r--r--@ 1 eskimo  staff    704 Dec  9 15:59 redhat-icon.woff2
drwxr-xr-x@ 5 eskimo  staff    160 Dec  9 15:59 www

tmp/extension/dist:
total 2344
-rw-r--r--@ 1 eskimo  staff  1198662 Dec  9 15:59 extension.cjs
drwxr-xr-x@ 3 eskimo  staff       96 Dec  9 15:59 node_modules
```