### PR TITLE
fix: eslint ignore files generated in Red Hat API

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,4 @@ www
 *.config.ts
 types/**/*.ts
 __mocks__
+src/rh-api/gen


### PR DESCRIPTION
Exclude generated file from `pnpm lint:check` to avoid report for multiple issues in them.