### PR TITLE
fix: pass urlProtocol as query parameter to sucess.html page

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "publisher": "redhat",
   "license": "Apache-2.0",
   "engines": {
-    "podman-desktop": "^1.10.0"
+    "podman-desktop": "^1.27.0"
   },
   "main": "./dist/extension.cjs",
   "contributes": {
@@ -50,8 +50,8 @@
     "test:e2e": "cross-env E2E_TESTS=true DEBUG=pw:channel:response,pw:channel:event npm run test:e2e:setup npx playwright test tests/src"
   },
   "dependencies": {
-    "@podman-desktop/api": "^1.14.1",
-    "@podman-desktop/podman-extension-api": "^1.26.2",
+    "@podman-desktop/api": "1.27.0-next.202604210820-677f704",
+    "@podman-desktop/podman-extension-api": "1.27.0-next.202604210820-677f704",
     "js-yaml": "^4.1.1",
     "object-hash": "3.0.0",
     "openapi-fetch": "^0.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,11 +15,11 @@ importers:
   .:
     dependencies:
       '@podman-desktop/api':
-        specifier: ^1.14.1
-        version: 1.14.1
+        specifier: 1.27.0-next.202604210820-677f704
+        version: 1.27.0-next.202604210820-677f704
       '@podman-desktop/podman-extension-api':
-        specifier: ^1.26.2
-        version: 1.26.2
+        specifier: 1.27.0-next.202604210820-677f704
+        version: 1.27.0-next.202604210820-677f704
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
@@ -434,14 +434,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@podman-desktop/api@1.14.1':
-    resolution: {integrity: sha512-mOX5XWAomOXgXt/S5o13t9LXSHylg8xvAzWYwIrHkXYQL6fy6QqChroezx6MlSotJ6bj1peHh0ToFfxVHTa79w==}
+  '@podman-desktop/api@1.27.0-next.202604210820-677f704':
+    resolution: {integrity: sha512-+c0/RX+37zd5O1BGomXCJFWkli1roQOfyyFbbw385fRagXXBLH9GK/6EbKg7a/T1Scsz/brztbPNMkFeXA+Rxw==}
 
-  '@podman-desktop/api@1.26.2':
-    resolution: {integrity: sha512-LE8uo8PsyUG7gfrg0IW/Eib6SeZn717usJSwiuzpDMTSZJCTwlaXDeEADxMXLfsu6V9OKjZtgwJ7SAVzaeTV7A==}
-
-  '@podman-desktop/podman-extension-api@1.26.2':
-    resolution: {integrity: sha512-WTs0NGjNRtpXQk3QElosyuWYv3sNh4AyZ5+BK6nJ5vCoaEcswcU7YeRJLwLV+vZqELM5f6arr+Gc+zr7cvYNNQ==}
+  '@podman-desktop/podman-extension-api@1.27.0-next.202604210820-677f704':
+    resolution: {integrity: sha512-nWsWU99ZU1AB7pYK/MYeM6CzEGc3ve3FvUDGMF0EDFNyCEyeMixNuf/VASyCm4jJn+R+KU3qgTILv5KqucOVrA==}
 
   '@podman-desktop/tests-playwright@1.26.2':
     resolution: {integrity: sha512-ojFIMT6XraFxp1+cIjVP+mwDAWMZM5HsJrPiq6WQEqMj5elt94NRGqaAYHxKEl/JaXI6CTFHIHYnzaQPgSdcmw==}
@@ -3069,13 +3066,11 @@ snapshots:
     dependencies:
       playwright: 1.59.1
 
-  '@podman-desktop/api@1.14.1': {}
+  '@podman-desktop/api@1.27.0-next.202604210820-677f704': {}
 
-  '@podman-desktop/api@1.26.2': {}
-
-  '@podman-desktop/podman-extension-api@1.26.2':
+  '@podman-desktop/podman-extension-api@1.27.0-next.202604210820-677f704':
     dependencies:
-      '@podman-desktop/api': 1.26.2
+      '@podman-desktop/api': 1.27.0-next.202604210820-677f704
 
   '@podman-desktop/tests-playwright@1.26.2': {}
 

--- a/src/authentication-service.ts
+++ b/src/authentication-service.ts
@@ -38,6 +38,8 @@ import { createServer, startServer } from './authentication-server';
 import type { AuthConfig } from './configuration';
 import Logger from './logger';
 
+const urlProtocol = (env as { urlProtocol?: string }).urlProtocol ?? 'podman-desktop';
+
 interface IToken {
   accessToken?: string; // When unable to refresh due to network problems, the access token becomes undefined
   idToken?: string; // depending on the scopes can be either supplied or empty
@@ -377,7 +379,7 @@ export class RedHatAuthenticationService {
       if ('err' in redirectReq) {
         const { err, res } = redirectReq;
         res.writeHead(302, {
-          Location: `/?service=${this.config.serviceId}&error=${encodeURIComponent((err as Error)?.message || 'Unknown error')}`,
+          Location: `/?service=${this.config.serviceId}&error=${encodeURIComponent((err as Error)?.message || 'Unknown error')}&protocol=${urlProtocol}`,
         });
         res.end();
         throw err;
@@ -437,7 +439,7 @@ export class RedHatAuthenticationService {
       const token = this.convertToken(tokenSet!, scope);
 
       callbackResult.res.writeHead(302, {
-        Location: `/?service=${this.config.serviceId}&login=${encodeURIComponent(token.account.label)}`,
+        Location: `/?service=${this.config.serviceId}&login=${encodeURIComponent(token.account.label)}&protocol=${urlProtocol}`,
       });
       callbackResult.res.end();
 
@@ -453,7 +455,7 @@ export class RedHatAuthenticationService {
 
   public error(response: ServerResponse, error: unknown): void {
     response.writeHead(302, {
-      Location: `/?error=${encodeURIComponent((error as Error)?.message || 'Unknown error')}`,
+      Location: `/?error=${encodeURIComponent((error as Error)?.message || 'Unknown error')}&protocol=${urlProtocol}`,
     });
     response.end();
   }

--- a/www/success.html
+++ b/www/success.html
@@ -12,7 +12,8 @@
     />
     <script lang="javascript">
       function onLoad() {
-        window.location.href = 'podman-desktop://'
+        var protocol = (/[?&]protocol=([^&]+)/.exec(window.location.search) || [])[1];
+        window.location.href = (protocol || 'podman-desktop') + '://';
       };
       window.onload = onLoad;
     </script>


### PR DESCRIPTION
This fixes #1070 by reading urlProtocol form env.urlProtocol and passing it as a query parameter to success.html page.

It depends on:
* https://github.com/podman-desktop/podman-desktop/pull/16965
* https://github.com/podman-desktop/podman-desktop/pull/16964