### PR TITLE
fix: remove SCA check from authentication workflow

### DIFF
--- a/src/extension.spec.ts
+++ b/src/extension.spec.ts
@@ -25,7 +25,6 @@ import { afterEach, beforeEach, expect, suite, test, vi } from 'vitest';
 import * as extension from './extension';
 import * as podmanCli from './podman-cli';
 import * as subscription from './rh-api/subscription';
-import { Organization } from './rh-api/subscription';
 import { ExtensionTelemetryLogger } from './telemetry';
 import * as util from './util';
 
@@ -125,80 +124,6 @@ suite('signin command telemetry reports', () => {
     expect(logSpy).toBeCalledWith('signin', {
       successful: false,
       error: 'Error: No running podman',
-      errorIn: 'subscription-activation',
-    });
-  });
-
-  test('unsuccessful login when simple content access is not enabled for account', async () => {
-    const logSpy = vi.spyOn(ExtensionTelemetryLogger, 'logUsage').mockImplementation(() => {
-      return;
-    });
-    let notificationCallback: (event: any) => Promise<any>;
-    let session: AuthenticationSession;
-    vi.mocked(authentication.onDidChangeSessions).mockImplementation((callback: (event: any) => Promise<any>) => {
-      notificationCallback = callback;
-      return {
-        dispose: vi.fn(),
-      };
-    });
-    vi.mocked(authentication.getSession).mockImplementation(
-      async (
-        _p1: string,
-        _p2: string[],
-        options: AuthenticationGetSessionOptions | undefined,
-      ): Promise<AuthenticationSession | undefined> => {
-        if (session) {
-          return Promise.resolve(session);
-        }
-        if (options?.createIfNone) {
-          session = {
-            id: '1',
-            accessToken: 'token',
-            scopes: ['scope1', 'scope2'],
-            account: {
-              id: 'accountId',
-              label: 'label',
-            },
-          };
-          await notificationCallback({
-            provider: {
-              id: 'redhat.authentication-provider',
-            },
-          });
-        }
-      },
-    );
-    let commandFunctionCopy: () => Promise<void>;
-    vi.mocked(commands.registerCommand).mockImplementation(
-      (commandId: string, commandFunction: () => Promise<void>) => {
-        if (commandId === 'redhat.authentication.signin') {
-          commandFunctionCopy = commandFunction;
-        }
-        return {
-          dispose: vi.fn(),
-        };
-      },
-    );
-    vi.spyOn(subscription, 'isRedHatRegistryConfigured').mockReturnValue(true);
-    vi.spyOn(podmanCli, 'getConnectionForRunningPodmanMachine').mockReturnValue({
-      providerId: '1',
-      connection: {
-        name: 'machine1',
-        type: 'podman',
-        endpoint: {
-          socketPath: '/path/to/the/socket',
-        },
-        status: () => 'started',
-      },
-    });
-    vi.spyOn(Organization.prototype, 'checkOrgScaCapability').mockResolvedValue({ body: {} });
-    await extension.activate(createExtContext());
-    expect(commandFunctionCopy!).toBeDefined();
-    await commandFunctionCopy!();
-    expect(authentication.onDidChangeSessions).toBeCalled();
-    expect(logSpy).toBeCalledWith('signin', {
-      successful: false,
-      error: 'Error: SCA is not enabled and message closed',
       errorIn: 'subscription-activation',
     });
   });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -154,16 +154,6 @@ async function createOrReuseActivationKey(connection: extensionApi.ProviderConta
   await runSubscriptionManagerRegister(connection, 'podman-desktop', accessTokenJson.organization.id);
 }
 
-async function isSimpleContentAccessEnabled(): Promise<boolean> {
-  const currentSession = await signIntoRedHatDeveloperAccount();
-  const client = new SubscriptionManagerClient({
-    BASE: 'https://console.redhat.com/api/rhsm/v2',
-    TOKEN: currentSession!.accessToken,
-  });
-  const data = await client.organization.checkOrgScaCapability();
-  return data?.body?.simpleContentAccess === 'enabled';
-}
-
 async function isSubscriptionManagerInstalled(connection: extensionApi.ProviderContainerConnection): Promise<boolean> {
   const exitCode = await runSubscriptionManager(connection);
   return exitCode === 0;
@@ -264,18 +254,6 @@ async function configureRegistryAndActivateSubscription(): Promise<void> {
               throw new Error('No running podman');
             }
           } else {
-            if (!(await isSimpleContentAccessEnabled())) {
-              const choice = await extensionApi.window.showInformationMessage(
-                'Simple Content Access (SCA) is not enabled for your Red Hat account. Please enable it and try again.',
-                'Close',
-                'Enable SCA',
-              );
-              if (choice === 'Enable SCA') {
-                await extensionApi.env.openExternal(extensionApi.Uri.parse('https://access.redhat.com/management'));
-                throw new Error('SCA is not enabled and subscription management page requested');
-              }
-              throw new Error('SCA is not enabled and message closed');
-            }
             if (!(await isSubscriptionManagerInstalled(runningConnection))) {
               await installSubscriptionManger(runningConnection);
               await runStopPodmanMachine(runningConnection);

--- a/src/rh-api/subscription.ts
+++ b/src/rh-api/subscription.ts
@@ -66,19 +66,10 @@ export class ActivationKey extends ClientHolder<paths> {
   }
 }
 
-export class Organization extends ClientHolder<paths> {
-  async checkOrgScaCapability() {
-    const response = await this.client.GET('/organization');
-    return response.data;
-  }
-}
-
 export class SubscriptionManagerClient extends ClientHolder<paths> {
   activationKey: ActivationKey;
-  organization: Organization;
   constructor(options: { BASE: string; TOKEN: string }) {
     super(createClient<paths>({ baseUrl: options.BASE }), options.TOKEN);
     this.activationKey = new ActivationKey(this.client);
-    this.organization = new Organization(this.client);
   }
 }


### PR DESCRIPTION
## Summary

- Removes the Simple Content Access (SCA) organization check that now returns 403 after a Red Hat subscription service update
- Removes the `Organization` class, `isSimpleContentAccessEnabled()` function, and related test
- SCA is no longer needed since all new users get SCA enabled by default

Closes #1162

AI assisted

Made with [Cursor](https://cursor.com)