### PR TITLE
fix: update version to 1.1.1 in 1.1.x branch before release

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "redhat-authentication",
   "displayName": "Red Hat Authentication",
   "description": "Login to Red Hat Developers",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b",
   "type": "module",
   "icon": "icon.png",


### PR DESCRIPTION
This PR sets release version to 1.1.1 in 1.1.x branch based on v1.1.0 tag to release SCA check removal fix.