### PR TITLE
fix: remove SCA check from authentication workflow

### DIFF
--- a/src/extension.spec.ts
+++ b/src/extension.spec.ts
@@ -24,7 +24,6 @@ import { afterEach, beforeEach, expect, suite, test, vi } from 'vitest';
 
 import * as extension from './extension';
 import * as podmanCli from './podman-cli';
-import * as subscription from './rh-api/subscription';
 import { ExtensionTelemetryLogger } from './telemetry';
 import * as util from './util';
 
@@ -115,7 +114,7 @@ suite('signin command telemetry reports', () => {
         };
       },
     );
-    vi.spyOn(subscription, 'isRedHatRegistryConfigured').mockResolvedValue(true);
+    vi.spyOn(util, 'isRedHatRegistryConfigured').mockResolvedValue(true);
     vi.spyOn(podmanCli, 'getConnectionForRunningPodmanMachine').mockReturnValue(undefined);
     await extension.activate(createExtContext());
     expect(commandFunctionCopy!).toBeDefined();

--- a/src/extension.spec.ts
+++ b/src/extension.spec.ts
@@ -25,7 +25,6 @@ import { afterEach, beforeEach, expect, suite, test, vi } from 'vitest';
 import * as extension from './extension';
 import * as podmanCli from './podman-cli';
 import * as subscription from './rh-api/subscription';
-import { Organization } from './rh-api/subscription';
 import { ExtensionTelemetryLogger } from './telemetry';
 import * as util from './util';
 
@@ -125,80 +124,6 @@ suite('signin command telemetry reports', () => {
     expect(logSpy).toBeCalledWith('signin', {
       successful: false,
       error: 'Error: No running podman',
-      errorIn: 'subscription-activation',
-    });
-  });
-
-  test('unsuccessful login when simple content access is not enabled for account', async () => {
-    const logSpy = vi.spyOn(ExtensionTelemetryLogger, 'logUsage').mockImplementation(() => {
-      return;
-    });
-    let notificationCallback: (event: any) => Promise<any>;
-    let session: AuthenticationSession;
-    vi.mocked(authentication.onDidChangeSessions).mockImplementation((callback: (event: any) => Promise<any>) => {
-      notificationCallback = callback;
-      return {
-        dispose: vi.fn(),
-      };
-    });
-    vi.mocked(authentication.getSession).mockImplementation(
-      async (
-        _p1: string,
-        _p2: string[],
-        options: AuthenticationGetSessionOptions | undefined,
-      ): Promise<AuthenticationSession | undefined> => {
-        if (session) {
-          return Promise.resolve(session);
-        }
-        if (options?.createIfNone) {
-          session = {
-            id: '1',
-            accessToken: 'token',
-            scopes: ['scope1', 'scope2'],
-            account: {
-              id: 'accountId',
-              label: 'label',
-            },
-          };
-          await notificationCallback({
-            provider: {
-              id: 'redhat.authentication-provider',
-            },
-          });
-        }
-      },
-    );
-    let commandFunctionCopy: () => Promise<void>;
-    vi.mocked(commands.registerCommand).mockImplementation(
-      (commandId: string, commandFunction: () => Promise<void>) => {
-        if (commandId === 'redhat.authentication.signin') {
-          commandFunctionCopy = commandFunction;
-        }
-        return {
-          dispose: vi.fn(),
-        };
-      },
-    );
-    vi.spyOn(subscription, 'isRedHatRegistryConfigured').mockReturnValue(true);
-    vi.spyOn(podmanCli, 'getConnectionForRunningPodmanMachine').mockReturnValue({
-      providerId: '1',
-      connection: {
-        name: 'machine1',
-        type: 'podman',
-        endpoint: {
-          socketPath: '/path/to/the/socket',
-        },
-        status: () => 'started',
-      },
-    });
-    vi.spyOn(Organization.prototype, 'checkOrgScaCapability').mockResolvedValue({ body: {} });
-    await extension.activate(createExtContext());
-    expect(commandFunctionCopy!).toBeDefined();
-    await commandFunctionCopy!();
-    expect(authentication.onDidChangeSessions).toBeCalled();
-    expect(logSpy).toBeCalledWith('signin', {
-      successful: false,
-      error: 'Error: SCA is not enabled and message closed',
       errorIn: 'subscription-activation',
     });
   });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,10 +33,10 @@ import {
   runSubscriptionManagerUnregister,
 } from './podman-cli';
 import { ContainerRegistryAuthorizerClient } from './rh-api/registry-authorizer';
-import { isRedHatRegistryConfigured, REGISTRY_REDHAT_IO, SubscriptionManagerClient } from './rh-api/subscription';
+import { SubscriptionManagerClient } from './rh-api/subscription';
 import { SSOStatusBarItem } from './status-bar-item';
 import { ExtensionTelemetryLogger as TelemetryLogger } from './telemetry';
-import { isLinux, signIntoRedHatDeveloperAccount } from './util';
+import { isLinux, isRedHatRegistryConfigured, REGISTRY_REDHAT_IO, signIntoRedHatDeveloperAccount } from './util';
 
 interface JwtToken {
   organization: {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -154,16 +154,6 @@ async function createOrReuseActivationKey(connection: extensionApi.ProviderConta
   await runSubscriptionManagerRegister(connection, 'podman-desktop', accessTokenJson.organization.id);
 }
 
-async function isSimpleContentAccessEnabled(): Promise<boolean> {
-  const currentSession = await signIntoRedHatDeveloperAccount();
-  const client = new SubscriptionManagerClient({
-    BASE: 'https://console.redhat.com/api/rhsm/v2',
-    TOKEN: currentSession!.accessToken,
-  });
-  const data = await client.organization.checkOrgScaCapability();
-  return data?.body?.simpleContentAccess === 'enabled';
-}
-
 async function isSubscriptionManagerInstalled(connection: extensionApi.ProviderContainerConnection): Promise<boolean> {
   const exitCode = await runSubscriptionManager(connection);
   return exitCode === 0;
@@ -264,18 +254,6 @@ async function configureRegistryAndActivateSubscription(): Promise<void> {
               throw new Error('No running podman');
             }
           } else {
-            if (!(await isSimpleContentAccessEnabled())) {
-              const choice = await extensionApi.window.showInformationMessage(
-                'Simple Content Access (SCA) is not enabled for your Red Hat account. Please enable it and try again.',
-                'Close',
-                'Enable SCA',
-              );
-              if (choice === 'Enable SCA') {
-                await extensionApi.env.openExternal(extensionApi.Uri.parse('https://access.redhat.com/management'));
-                throw new Error('SCA is not enabled and subscription management page requested');
-              }
-              throw new Error('SCA is not enabled and message closed');
-            }
             if (!(await isSubscriptionManagerInstalled(runningConnection))) {
               await installSubscriptionManger(runningConnection);
               await runStopPodmanMachine(runningConnection);

--- a/src/rh-api/subscription.ts
+++ b/src/rh-api/subscription.ts
@@ -66,19 +66,10 @@ export class ActivationKey extends ClientHolder<paths> {
   }
 }
 
-export class Organization extends ClientHolder<paths> {
-  async checkOrgScaCapability() {
-    const response = await this.client.GET('/organization');
-    return response.data;
-  }
-}
-
 export class SubscriptionManagerClient extends ClientHolder<paths> {
   activationKey: ActivationKey;
-  organization: Organization;
   constructor(options: { BASE: string; TOKEN: string }) {
     super(createClient<paths>({ baseUrl: options.BASE }), options.TOKEN);
     this.activationKey = new ActivationKey(this.client);
-    this.organization = new Organization(this.client);
   }
 }

--- a/src/rh-api/subscription.ts
+++ b/src/rh-api/subscription.ts
@@ -17,39 +17,10 @@
  ***********************************************************************/
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 
-import { accessSync, constants, readFileSync } from 'node:fs';
-import { homedir } from 'node:os';
-import path from 'node:path';
-
 import createClient from 'openapi-fetch';
 
 import type { paths } from './gen/subscription';
 import { ClientHolder } from './utils';
-
-export const REGISTRY_REDHAT_IO = 'registry.redhat.io';
-
-// TODO: add listRegistries to registry API to allow search by
-// registry URL
-export function isRedHatRegistryConfigured(): boolean {
-  const pathToAuthJson = path.join(homedir(), '.config', 'containers', 'auth.json');
-  let configured = false;
-  try {
-    // TODO: handle all kind problems with file existence, accessibility and parsable content
-    accessSync(pathToAuthJson, constants.R_OK);
-    const authFileContent = readFileSync(pathToAuthJson, { encoding: 'utf8' });
-    const authFileJson: {
-      auths?: {
-        [registryUrl: string]: {
-          auth: string;
-        };
-      };
-    } = JSON.parse(authFileContent);
-    configured = authFileJson?.auths?.prototype.hasOwnProperty.call(authFileJson?.auths, REGISTRY_REDHAT_IO) || false;
-  } catch (_notAccessibleError) {
-    // if file is not there, ignore and return default value
-  }
-  return configured;
-}
 
 export class ActivationKey extends ClientHolder<paths> {
   async createActivationKeys(body: { name: string; role: string; usage: string; serviceLevel: string }) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -16,7 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { platform } from 'node:os';
+import { accessSync, constants, readFileSync } from 'node:fs';
+import { homedir, platform } from 'node:os';
+import path from 'node:path';
 
 import type { AuthenticationSession } from '@podman-desktop/api';
 import { authentication } from '@podman-desktop/api';
@@ -43,4 +45,27 @@ export async function signIntoRedHatDeveloperAccount(createIfNone = true): Promi
     ], // scope that gives access to console.redhat.com APIs
     { createIfNone },
   );
+}
+
+export const REGISTRY_REDHAT_IO = 'registry.redhat.io';
+
+export function isRedHatRegistryConfigured(): boolean {
+  const pathToAuthJson = path.join(homedir(), '.config', 'containers', 'auth.json');
+  let configured = false;
+  try {
+    // TODO: handle all kind problems with file existence, accessibility and parsable content
+    accessSync(pathToAuthJson, constants.R_OK);
+    const authFileContent = readFileSync(pathToAuthJson, { encoding: 'utf8' });
+    const authFileJson: {
+      auths?: {
+        [registryUrl: string]: {
+          auth: string;
+        };
+      };
+    } = JSON.parse(authFileContent);
+    configured = authFileJson?.auths?.prototype.hasOwnProperty.call(authFileJson?.auths, REGISTRY_REDHAT_IO) || false;
+  } catch (_notAccessibleError) {
+    // if file is not there, ignore and return default value
+  }
+  return configured;
 }


### PR DESCRIPTION
The Simple Content Access (SCA) organization check is no longer needed and returns 403 after a Red Hat subscription service update. Remove the Organization class, the isSimpleContentAccessEnabled function, and related test.

Closes #1162