### PR TITLE
fix: improve the cookies dialog/iframe handling

### DIFF
--- a/tests/src/sso-extension.spec.ts
+++ b/tests/src/sso-extension.spec.ts
@@ -25,7 +25,7 @@ import type { ConfirmInputValue, NavigationBar} from '@podman-desktop/tests-play
 import { 
   ArchitectureType,
   AuthenticationPage, 
-  expect as playExpect, 
+  checkLocatorExistence,  expect as playExpect, 
   ExtensionCardPage, 
   findPageWithTitleInBrowser,
   getEntryFromConsoleLogs,
@@ -436,8 +436,16 @@ export async function terminateExternalBrowser(): Promise<void> {
 
 export async function handleCookies(page: Page, buttonName: string, timeout: number): Promise<void> {
   const iframe = page.frameLocator('iframe:visible');
-  const button = iframe.getByRole('button', { name: buttonName });
+  let cookiesContainer = undefined;
+  if (await checkLocatorExistence(iframe.owner())) {
+    cookiesContainer = iframe.owner();
+  }
+  else if (await checkLocatorExistence(page.getByRole('dialog'))) {
+    cookiesContainer = page.getByRole('dialog');
+  }
 
+  const regexp = new RegExp(buttonName);
+  const button = cookiesContainer ? cookiesContainer.getByRole('button', { name: regexp }) : page.getByRole('button', { name: regexp });
   try {
     await playExpect(button).toBeVisible({ timeout: timeout });
     await button.scrollIntoViewIfNeeded();


### PR DESCRIPTION
Fixes #1104 

Adds improved cookies handling since the trustarc content may appear in dialog instead of iframe.

Now it fails on: `ts.Red Hat Authentication extension verification › Verify authentication of the user via browser › User can authenticate via browser	❌ failure`

after change it should pass on this test case. But it fails on another, but that is other problem (https://github.com/redhat-developer/podman-desktop-redhat-account-ext/issues/1183)