### PR TITLE
feat(suggested-registry): provide additional config handler for registry authorizer

### DIFF
--- a/src/extension.spec.ts
+++ b/src/extension.spec.ts
@@ -52,12 +52,13 @@ afterEach(() => {
 suite('extension activation', () => {
   test('register commands declared in package.json', async () => {
     await extension.activate(createExtContext());
-    expect(commands.registerCommand).toHaveBeenCalledTimes(5);
+    expect(commands.registerCommand).toHaveBeenCalledTimes(6);
     expect(commands.registerCommand).toHaveBeenCalledWith('redhat.authentication.signin', expect.anything());
     expect(commands.registerCommand).toHaveBeenCalledWith('redhat.authentication.navigate.settings', expect.anything());
     expect(commands.registerCommand).toHaveBeenCalledWith('redhat.authentication.signout', expect.anything());
     expect(commands.registerCommand).toHaveBeenCalledWith('redhat.authentication.signup', expect.anything());
     expect(commands.registerCommand).toHaveBeenCalledWith('redhat.authentication.isSignedIn', expect.anything());
+    expect(commands.registerCommand).toHaveBeenCalledWith('redhat.authentication.configureRegistry', expect.anything());
     expect(authentication.onDidChangeSessions).toHaveBeenCalled();
   });
 });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -307,6 +307,13 @@ export async function activate(context: extensionApi.ExtensionContext): Promise<
   authenticationServicePromise = buildAndInitializeAuthService(context, statusBarItem);
 
   context.subscriptions.push(
+    extensionApi.commands.registerCommand(
+      'redhat.authentication.configureRegistry',
+      ssoConfigHandler,
+    ),
+  );
+
+  context.subscriptions.push(
     extensionApi.registry.suggestRegistry({
       name: 'Red Hat Container Registry',
       icon,
@@ -314,8 +321,7 @@ export async function activate(context: extensionApi.ExtensionContext): Promise<
       additionalConfigHandlers: [
         {
           label: 'Red Hat SSO',
-          isDefault: true,
-          handler: ssoConfigHandler,
+          commandId: 'redhat.authentication.configureRegistry',
         },
       ],
     }),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -202,9 +202,37 @@ async function buildAndInitializeAuthService(
 }
 
 interface StepTelemetryData {
-  errorIn?: 'sign-in' | 'registry-configuration' | 'subscription-activation';
+  errorIn?: 'sign-in' | 'registry-configuration' | 'subscription-activation' | 'registry-config-handler';
   error?: string;
   successful: boolean;
+}
+
+async function ssoConfigHandler(): Promise<void> {
+  const telemetryData: StepTelemetryData = {
+    successful: true,
+  };
+  await configureRegistryWithProgress().catch((error: unknown) => {
+    telemetryData.errorIn = 'registry-config-handler';
+    telemetryData.error = String(error);
+    telemetryData.successful = false;
+  });
+  TelemetryLogger.logUsage('signin', telemetryData);
+}
+
+async function configureRegistryWithProgress(): Promise<void> {
+  return extensionApi.window.withProgress(
+    {
+      location: extensionApi.ProgressLocation.TASK_WIDGET,
+      title: 'Configuring Red Hat Registry',
+    },
+    async progress => {
+      // Checking if registry account for https://registry.redhat.io is already configured
+      if (!isRedHatRegistryConfigured()) {
+        progress.report({ increment: 30 });
+        await createOrReuseRegistryServiceAccount();
+      }
+    },
+  );
 }
 
 async function configureRegistryAndActivateSubscription(): Promise<void> {
@@ -212,26 +240,11 @@ async function configureRegistryAndActivateSubscription(): Promise<void> {
     successful: true,
   };
 
-  await extensionApi.window
-    .withProgress(
-      {
-        location: extensionApi.ProgressLocation.TASK_WIDGET,
-        title: 'Configuring Red Hat Registry',
-      },
-      async progress => {
-        // Checking if registry account for https://registry.redhat.io is already configured
-        if (!isRedHatRegistryConfigured()) {
-          progress.report({ increment: 30 });
-          await createOrReuseRegistryServiceAccount();
-        }
-      },
-    )
-    .then(() => false)
-    .catch((error: unknown) => {
-      telemetryData.errorIn = 'registry-configuration';
-      telemetryData.error = String(error);
-      telemetryData.successful = false;
-    });
+  await configureRegistryWithProgress().catch((error: unknown) => {
+    telemetryData.errorIn = 'registry-configuration';
+    telemetryData.error = String(error);
+    telemetryData.successful = false;
+  });
 
   if (telemetryData.successful) {
     await extensionApi.window
@@ -298,6 +311,13 @@ export async function activate(context: extensionApi.ExtensionContext): Promise<
       name: 'Red Hat Container Registry',
       icon,
       url: 'registry.redhat.io',
+      additionalConfigHandlers: [
+        {
+          label: 'Red Hat SSO',
+          isDefault: true,
+          handler: ssoConfigHandler,
+        },
+      ],
     }),
   );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -307,10 +307,7 @@ export async function activate(context: extensionApi.ExtensionContext): Promise<
   authenticationServicePromise = buildAndInitializeAuthService(context, statusBarItem);
 
   context.subscriptions.push(
-    extensionApi.commands.registerCommand(
-      'redhat.authentication.configureRegistry',
-      ssoConfigHandler,
-    ),
+    extensionApi.commands.registerCommand('redhat.authentication.configureRegistry', ssoConfigHandler),
   );
 
   context.subscriptions.push(


### PR DESCRIPTION
This PR provides  'Red Hat SSO` named config handler that request login with SSO and then calls registry authorizer REST API to configure access to registry.redhat.io.

Depends on implementation of new API and UI which are tracked here https://github.com/podman-desktop/podman-desktop/issues/18133.

https://private-user-images.githubusercontent.com/620330/610260848-d9d69dbd-2027-4f21-b228-3d3aed8404e9.mov?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3ODI4OTMyODksIm5iZiI6MTc4Mjg5Mjk4OSwicGF0aCI6Ii82MjAzMzAvNjEwMjYwODQ4LWQ5ZDY5ZGJkLTIwMjctNGYyMS1iMjI4LTNkM2FlZDg0MDRlOS5tb3Y_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjYwNzAxJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI2MDcwMVQwODAzMDlaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT1jYWUzYWYzZWE1MDE4M2UzNjc0NThjYTJjMTlkYzBlNTkxODEwZjRkZTc5NTczZGMxMjlmNmRlMDY4NDBhMWI3JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZyZXNwb25zZS1jb250ZW50LXR5cGU9dmlkZW8lMkZxdWlja3RpbWUifQ.mSyvHpaUPep5JAALb8H5tFuUpSeIlsUW4XBbUZ77uao

Closes #1216.
