### PR TITLE
fix: resolve CVE-2026-13149 in brace-expansion

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
       "ajv": "^6.14.0",
       "minimatch@^3": "^3.1.5",
       "minimatch@^9": "^9.0.7",
-      "esbuild": "^0.28.1"
+      "esbuild": "^0.28.1",
+      "brace-expansion@^1": "^1.1.16"
     }
   },
   "extensionDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   minimatch@^3: ^3.1.5
   minimatch@^9: ^9.0.7
   esbuild: ^0.28.1
+  brace-expansion@^1: ^1.1.16
 
 importers:
 
@@ -927,8 +928,8 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
@@ -3325,7 +3326,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  brace-expansion@1.1.15:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -4355,7 +4356,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 1.1.16
 
   minimatch@9.0.9:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-13149 in `brace-expansion`.

**Advisory**: brace-expansion: DoS via exponential-time expansion of consecutive non-expanding {} groups
**Vulnerable versions**: <1.1.16
**Patched versions**: >=1.1.16
**Advisory URL**: https://github.com/advisories/GHSA-3jxr-9vmj-r5cp

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-13149: _brace-expansion: DoS via exponential-time expansion of consecutive non-expanding {} groups_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-13149 is no longer reported