### PR TITLE
fix: add parameter to run build with specific ref

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,11 @@ on:
       registry:
         required: false
         type: string
+      ref:
+        description: 'Git branch or tag to build from'
+        required: false
+        type: string
+        default: main
 
 jobs:
   build:
@@ -22,6 +27,8 @@ jobs:
   
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
 
       - uses: pnpm/action-setup@v6
         name: Install pnpm

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -31,6 +31,7 @@ jobs:
     uses: ./.github/workflows/build.yaml
     with:
       runs-on: ${{ matrix.target }}
+      ref: ${{ github.sha }}
  
   test:
     name: Test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -117,6 +117,7 @@ jobs:
       runs-on: ubuntu-latest
       registry: quay
       ext-version: ${{ needs.tag.outputs.extVersion }}
+      ref: ${{ needs.tag.outputs.githubTag }}
 
   release:
     needs: [tag, build]


### PR DESCRIPTION
This change is requiered to release SSO extension with new workflow. build.yaml workflow always builds from main. New workflow changes the version by removing -next from version then commit and push it to a tag. Then run the build.yaml workflow that builds from main.

The fix adds ref parameter to build workflow, so all workflow using it can tell where to build from.